### PR TITLE
Remove usage of std::unordered_map<>::reverse_iterator.

### DIFF
--- a/SADXModLoader/IniFile.cpp
+++ b/SADXModLoader/IniFile.cpp
@@ -147,16 +147,6 @@ std::unordered_map<string, string>::const_iterator IniGroup::cbegin() const
 	return m_data.cbegin();
 }
 
-std::unordered_map<string, string>::reverse_iterator IniGroup::rbegin()
-{
-	return m_data.rbegin();
-}
-
-std::unordered_map<string, string>::const_reverse_iterator IniGroup::crbegin() const
-{
-	return m_data.crbegin();
-}
-
 std::unordered_map<string, string>::iterator IniGroup::end()
 {
 	return m_data.end();
@@ -165,16 +155,6 @@ std::unordered_map<string, string>::iterator IniGroup::end()
 std::unordered_map<string, string>::const_iterator IniGroup::cend() const
 {
 	return m_data.cend();
-}
-
-std::unordered_map<string, string>::reverse_iterator IniGroup::rend()
-{
-	return m_data.rend();
-}
-
-std::unordered_map<string, string>::const_reverse_iterator IniGroup::crend() const
-{
-	return m_data.crend();
 }
 
 /** IniFile **/
@@ -362,16 +342,6 @@ std::unordered_map<string, IniGroup*>::const_iterator IniFile::cbegin() const
 	return m_groups.cbegin();
 }
 
-std::unordered_map<string, IniGroup*>::reverse_iterator IniFile::rbegin()
-{
-	return m_groups.rbegin();
-}
-
-std::unordered_map<string, IniGroup*>::const_reverse_iterator IniFile::crbegin() const
-{
-	return m_groups.crbegin();
-}
-
 std::unordered_map<string, IniGroup*>::iterator IniFile::end()
 {
 	return m_groups.end();
@@ -380,16 +350,6 @@ std::unordered_map<string, IniGroup*>::iterator IniFile::end()
 std::unordered_map<string, IniGroup*>::const_iterator IniFile::cend() const
 {
 	return m_groups.cend();
-}
-
-std::unordered_map<string, IniGroup*>::reverse_iterator IniFile::rend()
-{
-	return m_groups.rend();
-}
-
-std::unordered_map<string, IniGroup*>::const_reverse_iterator IniFile::crend() const
-{
-	return m_groups.crend();
 }
 
 /**

--- a/SADXModLoader/IniFile.hpp
+++ b/SADXModLoader/IniFile.hpp
@@ -32,12 +32,8 @@ class IniGroup
 
 		std::unordered_map<std::string, std::string>::iterator begin();
 		std::unordered_map<std::string, std::string>::const_iterator cbegin() const;
-		std::unordered_map<std::string, std::string>::reverse_iterator rbegin();
-		std::unordered_map<std::string, std::string>::const_reverse_iterator crbegin() const;
 		std::unordered_map<std::string, std::string>::iterator end();
 		std::unordered_map<std::string, std::string>::const_iterator cend() const;
-		std::unordered_map<std::string, std::string>::reverse_iterator rend();
-		std::unordered_map<std::string, std::string>::const_reverse_iterator crend() const;
 
 	protected:
 		friend class IniFile;
@@ -77,12 +73,8 @@ class IniFile
 
 		std::unordered_map<std::string, IniGroup*>::iterator begin();
 		std::unordered_map<std::string, IniGroup*>::const_iterator cbegin() const;
-		std::unordered_map<std::string, IniGroup*>::reverse_iterator rbegin();
-		std::unordered_map<std::string, IniGroup*>::const_reverse_iterator crbegin() const;
 		std::unordered_map<std::string, IniGroup*>::iterator end();
 		std::unordered_map<std::string, IniGroup*>::const_iterator cend() const;
-		std::unordered_map<std::string, IniGroup*>::reverse_iterator rend();
-		std::unordered_map<std::string, IniGroup*>::const_reverse_iterator crend() const;
 
 	protected:
 		void load(FILE *f);


### PR DESCRIPTION
std::unordered_map doesn't have a reverse_iterator class. It never did, and it makes no sense, since it's an *unordered* map. However, MSVC 2013 (and possibly earlier versions) incorrectly provided a reverse_iterator class. MSVC 2015 removes it, which breaks IniFile.

Nothing actually makes use of the reverse_iterator functions, so simply removing them mostly fixes the MSVC 2015 build. There's another issue where printf() and scanf() functions were all inlined in MSVC 2015's CRT headers, which breaks the build because d3dx8.lib uses sprintf(). Adding legacy_stdio_definitions.lib fixes this, but that requires MSVC 2015.