### PR TITLE
MSVC 2015: Link in legacy_stdio_definitions.lib to fix undefined reference to _sprintf.

### DIFF
--- a/SADXModLoader/TextureReplacement.cpp
+++ b/SADXModLoader/TextureReplacement.cpp
@@ -1,5 +1,14 @@
 #include "stdafx.h"
 
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+// MSVC 2015 inlines printf() and scanf() functions.
+// As a result, MSVCRT no longer has definitions for them, resulting
+// in a linker error because d3dx8.lib depends on sprintf().
+// Link in legacy_stdio_definitions.lib to fix this.
+// Reference: https://msdn.microsoft.com/en-us/library/Bb531344.aspx
+#pragma comment(lib, "legacy_stdio_definitions.lib")
+#endif
+
 // Windows
 #include <d3dx8tex.h>
 #include <Windows.h>

--- a/SADXModLoader/stdafx.h
+++ b/SADXModLoader/stdafx.h
@@ -11,7 +11,6 @@
 #include <windows.h>
 
 // TODO: reference additional headers your program requires here
-#include <d3dx8tex.h>
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>

--- a/SADXModLoader/stdafx.h
+++ b/SADXModLoader/stdafx.h
@@ -11,6 +11,7 @@
 #include <windows.h>
 
 // TODO: reference additional headers your program requires here
+#include <d3dx8tex.h>
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
d3dx8.lib depends on sprintf(), but Microsoft decided to inline most of the printf() and scanf() functions in the MSVC 2015 runtime. To fix this, we have to link in legacy_stdio_definitions.lib.

Reference: https://msdn.microsoft.com/en-us/library/Bb531344.aspx