### PR TITLE
Fixed widescreen pause menu positioning

### DIFF
--- a/SADXModLoader/FixFOV.cpp
+++ b/SADXModLoader/FixFOV.cpp
@@ -124,4 +124,9 @@ void ConfigureFOV()
 	WriteJump((void*)0x0040872A, &dothething);
 
 	SetHorizontalFOV_BAMS_hook(bams_default);
+	
+	/* Stops the Pause Menu from using horizontal stretch in place of vertical stretch in coordinate calculation */
+	WriteData((uint8_t*)0x00457F69, (uint8_t)0xC4); // Elipse/Oval
+	WriteData((uint8_t*)0x004584EE, (uint8_t)0xC4); // Blue Transparent Box
+	WriteData((uint8_t*)0x0045802F, (uint8_t)0xC4); // Pause Menu Options
 }


### PR DESCRIPTION
The pause menu would appear off-centered when in a "widescreen" resolution, due to the fact that the game assumes there will always be a 4:3 resolution, and thus uses the horizontal stretch value in place of the vertical stretch value (despite actually having the vertical stretch in memory?). 

The way to fix this is to just change the address that is referenced from 008928C0 (horizontal stretch) to 008928C4 (vertical stretch) in the set of instructions used for calculating the y-coordinates of the separate pause menu pieces.