### PR TITLE
Various improvements, including a ~30k code size reduction.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,219 @@
-Sonic Adventure DX PC Mod Loader
-================================
-Changelog
+# Sonic Adventure DX PC Mod Loader
+## Changelog
 
+### Version 3.7-17q2 [commits up to 2017/06/30]
 
-What's new in Version 3.1?
---------------------------
+* Fix a HUD scaling oversight that could cause sprites to either disappear
+  or be locked in the middle of the screen.
+
+* Fixed a performance issue on some systems when window resizing is
+  disabled.
+
+* SADX Mod Manager:
+  * Added support for changelogs in modular updates.
+  * Handle symbolic links correctly.
+
+* Added scaling for menus, which includes the custom background image,
+  character select, options, and sound test.
+
+* Fixed a half-pixel offset error caused by SADX adding a half-pixel
+  instead of subtracting a half-pixel.
+
+* Scale title cards as well.
+
+* Added options to control FMV, background, and HUD scaling independently.
+
+* Fixed mipmap generation issues.
+
+* Use templates for WriteData() to avoid dynamic array allocations.
+
+### Version 3.7-17q1 [commits up to 2017/03/31]
+
+* Fixed a bug that prevented the Goal Ring mod from loading its PVM.
+
+* Added a code for longer title card display.
+
+* SADX Mod Manager: Added a manifest file to enable DPI awareness.
+
+* Fixed INI data processing for `triallevellist`, `soundtestlist`,
+  `musiclist`, `soundlist` and `stringarray` types.
+
+* Use ANSI functions when handling the main SADX window.
+  This fixes the window title.
+  FIXME: Need to make sure we do this for accelerators if loading
+  from the resource file? commit e1bcb951
+
+* Added a mod.ini option to use a custom window title.
+
+* Added a code to enable the unused "Tornado 2" health bar in
+  Sky Chase Act 2.
+
+* Upgraded the compiler to MSVC 2017. (was previously MSVC 2015)
+
+* Various updates to SADX Mod Manager, including fixes for the
+  automatic updater.
+
+* Make sure texpack folders have `index.txt` before registering them.
+
+* SADX Mod Manager: Added a "Window Resize" checkbox.
+
+* Enabling windowed mode should not make the window Always On Top.
+
+* Allow switching from initial fullscreen mode to windowed mode.
+
+* New HUD scaling infrastructure that rescales UI elements to match
+  their expected size when using resolutions larger than 640x480.
+  (Currently disabled for Chao Garden due to issues.)
+
+### Version 3.7-16q4 [commits up to 2016/12/31]
+
+* Upgraded the compiler to MSVC 2015. (was previously MSVC 2013)
+
+* Fixed another NPC text INI bug caused by incorrect variable usage.
+
+* SADX Mod Manager:
+  * Improve performance of mod.ini searching by stopping immediately
+    once mod.ini is found.
+  * Added automatic update notifications.
+
+* Texture replacement improvements, including a reference count fix.
+
+* Added more function definitions to SADXFunctions.h.
+
+* Prevent the "Super Sonic Flag" code from taking effect on the
+  Character Select screen.
+
+### Version 3.7-16q3 [commits up to 2016/09/30]
+
+* Added proper types to several SADX function declarations.
+
+* Initial C++ classes for encapsulating game objects.
+  See GameObject.cpp and GoalRing.cpp in libmodutils.
+
+* Disable the first-person camera when camera controls are disabled.
+
+* Fixed an off-by-one error in recap and NPC text INI replacements.
+
+* Added handling for trampolines on trampolines.
+
+### Version 3.7-16q2 [commits up to 2016/06/30]
+
+* Added support for folder-based sound effect packs.
+
+* Improve sprite alignment in the HUD scaling code.
+
+### Version 3.7-16q1 [commits up to 2016/03/31]
+
+* Added new code types: `writenop`, `writenopreg`
+
+* Added a code for "Disable Debug Spam".
+
+* Increased the maximum mod count from 998 to 999!
+
+* Added support for writing to INI files.
+
+* Added a mipmap blacklist to prevent UI textures from being mipmapped,
+  since that results in blurriness in menus and other UI elements.
+
+* Upgraded SADX Mod Manager to .NET 4.0. Replaced MDX with SharpDX.
+
+* Added a V-sync toggle.
+
+* Added a code for Infinite Tails flight.
+
+* Added documentation for codev4 and codev5. (@DankRank)
+
+* Implemented scaling for HUD objects when using resolutions higher
+  than 640x480.
+
+* Added lots of new enum, function, struct, and variable definitions
+  to their respective SADX header files.
+
+* Moved several classes out of SADX Mod Loader and into a new
+  git submodule, `mod-loader-common`.
+
+### Version 3.7 [released 2016/01/17]
+
+* Added support for per-mod code lists.
+
+* Added patches to the code system.
+
+### Version 3.6 [released 2016/01/02]
+
+* Imported the SADX Mod Manager frontend into the SADX Mod Loader repository.
+
+* Added a fix to maintain aspect ratio when playing videos.
+
+* Fixed vertical offsets for Pause sub-menus.
+
+* Fixed video scaling with videos of sizes other than 640x480.
+
+### Version 3.5 [released 2015/12/14]
+
+* Added a toggle for automatic mipmap generation. (default is on)
+  Auto Mipmap generation now respects textures that already have mipmaps
+  built-in, so it won't re-generate them.
+
+* Added mipmap generation for palettized textures. (default is off)
+
+* Allow exclusive fullscreen on secondary displays if multiple monitors
+  are connected.
+
+* Added a toggle for texture filtering.
+
+* Added an option to set a custom window size.
+
+### Version 3.4 [released 2015/09/14]
+
+* Split the dllmain.cpp file into multiple files in order to make it
+  easier to maintain.
+
+* Fix the FOV when using widescreen resolutions. When using a widescreen
+  resolution, the non-4:3 area will now extend past what you were able to
+  see before, instead of simply cropping the top and bottom of the 4:3
+  image to fit the screen.
+
+* Added more PVR texture replacement functionality, including support for
+  stray textures and subdirectories. Implemented a GBIX cache as well.
+
+* Fixed compilation with MSVC 2015.
+
+### Version 3.3 [released 2015/07/12]
+
+* Added support for DLL data replacement INIs.
+
+* Added a texture cache using PVR Global Indexes. (GBIX)
+
+* Switched from D3D9 to D3D8 for better compatibility with the base
+  SADX code, which was written for D3D8.
+
+* Added internal support for extra Dreamcast buttons:
+  * C, D, second D-pad
+
+* Added support for texture packs.
+
+* Added switching between fullscreen and windowed modes at runtime.
+  This includes the ability to run at any resolution in windowed
+  and windowed fullscreen modes, as well as multi-monitor support.
+
+* Upgraded the compiler to MSVC 2013. (was previously MSVC 2010)
+
+* More support for reading data from INI files, including `startpos`,
+  `texlist`, `leveltexlist`, and `triallevellist`.
+
+* Removed the CMake build system, since the project will only ever
+  be built using MSVC.
+
+### Version 3.2 [released 2015/02/24]
+
+* Added new cheat code types for type conversion.
+
+* Added support for loading data from INI files. This initially only
+  supports deathzones.
+
+* New module function API with separated data types.
+
+### Version 3.1 [released 2015/02/08]
 
 * Rewrote the build system using CMake instead of relying on
   Visual Studio projects.
@@ -22,7 +231,17 @@ What's new in Version 3.1?
 
 * Initial documentation for the binary code file format.
 
-What's new in Version 3.0?
---------------------------
+### What's new in Version 3.0?
 
 [this section needs to be filled out later]
+
+### Notes
+
+Release notes for v3.2 and v3.4 through v3.7 are estimated, since these
+versions were not been tagged. The tags used (v3.x-estimated) indicate
+when the version number was incremented in version.h.
+
+v3.7 was released on 2016/01/17. There hasn't been a version bump since,
+so changes since v3.7 are listed at the end of each quarter.
+
+Changes are listed in ascending order, chronologically.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,13 @@
-Sonic Adventure DX PC Mod Loader
-================================
-Version 3.1
+# Sonic Adventure DX PC Mod Loader
+Version 3.7
 
-
-Table of Contents
------------------
-
-1. System Requirements
-2. License
-3. Trademarks
-
-
-1. System Requirements
-----------------------
+## System Requirements
 
 To use SADX Mod Loader, you must have:
-  * Sonic Adventure DX PC, 2004 version (US release)
+* Sonic Adventure DX PC, 2004 version (US release)
+* Windows XP or later
 
-
-2. License
-----------
+## License
 
 DISCLAIMER:
 Any and all content presented in this repository is presented for
@@ -30,8 +18,7 @@ using this content responsibly. Sonic Retro claims no responsibility
 or warranty.
 
 
-3. Trademarks
--------------
+## Trademarks
 
 Sega, Sonic, Sonic the Hedgehog, and Sonic Adventure DX are either
 trademarks or registered trademarks of SEGA of America, Inc.

--- a/SADXModLoader/FileMap.cpp
+++ b/SADXModLoader/FileMap.cpp
@@ -120,7 +120,7 @@ void FileMap::scanFolder(const string &srcPath, int modIdx)
  * @param srcLen Length of original srcPath. (used for recursion)
  * @param modIdx Index of the current mod.
  */
-void FileMap::scanFolder_int(const std::string &srcPath, int srcLen, int modIdx)
+void FileMap::scanFolder_int(const string &srcPath, int srcLen, int modIdx)
 {
 	WIN32_FIND_DATAA data;
 	char path[MAX_PATH];
@@ -146,8 +146,8 @@ void FileMap::scanFolder_int(const std::string &srcPath, int srcLen, int modIdx)
 		if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		{
 			// Recursively scan this directory.
-			snprintf(path, sizeof(path), "%s\\%s", srcPath.c_str(), data.cFileName);
-			scanFolder_int(path, srcLen, modIdx);
+			const string newSrcPath = srcPath + "\\" + string(data.cFileName);
+			scanFolder_int(newSrcPath, srcLen, modIdx);
 		}
 		else
 		{

--- a/SADXModLoader/FileMap.cpp
+++ b/SADXModLoader/FileMap.cpp
@@ -146,13 +146,13 @@ void FileMap::scanFolder_int(const string &srcPath, int srcLen, int modIdx)
 		if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		{
 			// Recursively scan this directory.
-			const string newSrcPath = srcPath + "\\" + string(data.cFileName);
+			const string newSrcPath = srcPath + '\\' + string(data.cFileName);
 			scanFolder_int(newSrcPath, srcLen, modIdx);
 		}
 		else
 		{
 			// Create the mod filename and original filename.
-			string modFile = srcPath + "\\" + string(data.cFileName);
+			string modFile = srcPath + '\\' + string(data.cFileName);
 			transform(modFile.begin(), modFile.end(), modFile.begin(), ::tolower);
 
 			// Original filename.
@@ -203,7 +203,7 @@ void FileMap::scanSoundFolder(const std::string &srcPath)
 			_stricmp(".wma", PathFindExtensionA(data.cFileName)))
 		{
 			// Create the mod filename and original filename.
-			string modFile = srcPath + "\\" + string(data.cFileName);
+			string modFile = srcPath + '\\' + string(data.cFileName);
 			transform(modFile.begin(), modFile.end(), modFile.begin(), ::tolower);
 			// Original filename should have a ".wma" extension.
 			string origFile = modFile;
@@ -270,7 +270,7 @@ void FileMap::scanTextureFolder(const string& srcPath, int modIndex)
 			string original = "system\\" + fileName + ".pvm";
 			transform(original.begin(), original.end(), original.begin(), ::tolower);
 
-			string texPack = srcPath + "\\" + fileName;
+			string texPack = srcPath + '\\' + fileName;
 			transform(texPack.begin(), texPack.end(), texPack.begin(), ::tolower);
 
 			// Since we don't attempt to parse this file, make sure it exists
@@ -296,7 +296,7 @@ void FileMap::scanTextureFolder(const string& srcPath, int modIndex)
 			string original = "system\\" + noExt + ".pvm";
 			transform(original.begin(), original.end(), original.begin(), ::tolower);
 
-			string texPack = srcPath + "\\" + fileName;
+			string texPack = srcPath + '\\' + fileName;
 			transform(texPack.begin(), texPack.end(), texPack.begin(), ::tolower);
 			
 			m_fileMap[original] = { texPack, modIndex };

--- a/SADXModLoader/FileMap.cpp
+++ b/SADXModLoader/FileMap.cpp
@@ -22,13 +22,10 @@ using std::unordered_map;
 #include <shlwapi.h>
 
 FileMap::FileMap()
-{
-}
+{ }
 
 FileMap::~FileMap()
-{
-	clear();
-}
+{ }
 
 /**
  * Replace slash characters with backslashes.
@@ -126,8 +123,9 @@ void FileMap::scanFolder(const string &srcPath, int modIdx)
 void FileMap::scanFolder_int(const std::string &srcPath, int srcLen, int modIdx)
 {
 	WIN32_FIND_DATAA data;
-	string srcPathSearch = srcPath + "\\*";
-	HANDLE hFind = FindFirstFileA(srcPathSearch.c_str(), &data);
+	char path[MAX_PATH];
+	snprintf(path, sizeof(path), "%s\\*", srcPath.c_str());
+	HANDLE hFind = FindFirstFileA(path, &data);
 
 	// No files found.
 	if (hFind == INVALID_HANDLE_VALUE)
@@ -148,8 +146,8 @@ void FileMap::scanFolder_int(const std::string &srcPath, int srcLen, int modIdx)
 		if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		{
 			// Recursively scan this directory.
-			string newSrcPath = srcPath + "\\" + string(data.cFileName);
-			scanFolder_int(newSrcPath, srcLen, modIdx);
+			snprintf(path, sizeof(path), "%s\\%s", srcPath.c_str(), data.cFileName);
+			scanFolder_int(path, srcLen, modIdx);
 		}
 		else
 		{
@@ -157,17 +155,15 @@ void FileMap::scanFolder_int(const std::string &srcPath, int srcLen, int modIdx)
 			string modFile = srcPath + "\\" + string(data.cFileName);
 			transform(modFile.begin(), modFile.end(), modFile.begin(), ::tolower);
 
-			string fileBase = modFile.substr(srcLen);
-			string origFile = "system\\" + fileBase;
+			// Original filename.
+			string origFile = "system\\" + modFile.substr(srcLen);
 
-			if (!origFile.compare(0, 25, "system\\sounddata\\bgm\\wma\\")
-				|| !origFile.compare(0, 29, "system\\sounddata\\voice_us\\wma")
-				|| !origFile.compare(0, 29, "system\\sounddata\\voice_jp\\wma"))
+			if (!origFile.compare(0, 25, "system\\sounddata\\bgm\\wma\\") ||
+			    !origFile.compare(0, 30, "system\\sounddata\\voice_us\\wma\\") ||
+			    !origFile.compare(0, 30, "system\\sounddata\\voice_jp\\wma\\"))
 			{
-				char pathcstr[MAX_PATH];
-				strncpy(pathcstr, origFile.c_str(), sizeof(pathcstr));
-				PathRenameExtensionA(pathcstr, ".wma");
-				origFile = pathcstr;
+				// Original filename should have a ".wma" extension.
+				ReplaceFileExtension(origFile, ".wma");
 			}
 			setReplaceFile(origFile, modFile, modIdx);
 		}
@@ -183,8 +179,9 @@ void FileMap::scanFolder_int(const std::string &srcPath, int srcLen, int modIdx)
 void FileMap::scanSoundFolder(const std::string &srcPath)
 {
 	WIN32_FIND_DATAA data;
-	string srcPathSearch = srcPath + "\\*";
-	HANDLE hFind = FindFirstFileA(srcPathSearch.c_str(), &data);
+	char path[MAX_PATH];
+	snprintf(path, sizeof(path), "%s\\*", srcPath.c_str());
+	HANDLE hFind = FindFirstFileA(path, &data);
 
 	// No files found.
 	if (hFind == INVALID_HANDLE_VALUE)
@@ -202,15 +199,15 @@ void FileMap::scanSoundFolder(const std::string &srcPath)
 			continue;
 		}
 
-		if (!(data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && stricmp(".wma", PathFindExtensionA(data.cFileName)))
+		if (!(data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
+			_stricmp(".wma", PathFindExtensionA(data.cFileName)))
 		{
 			// Create the mod filename and original filename.
 			string modFile = srcPath + "\\" + string(data.cFileName);
 			transform(modFile.begin(), modFile.end(), modFile.begin(), ::tolower);
-			char pathcstr[MAX_PATH];
-			strncpy(pathcstr, modFile.c_str(), sizeof(pathcstr));
-			PathRenameExtensionA(pathcstr, ".wma");
-			string origFile = pathcstr;
+			// Original filename should have a ".wma" extension.
+			string origFile = modFile;
+			ReplaceFileExtension(origFile, ".wma");
 			m_fileMap[origFile] = { modFile };
 		}
 	} while (FindNextFileA(hFind, &data) != 0);
@@ -218,13 +215,14 @@ void FileMap::scanSoundFolder(const std::string &srcPath)
 	FindClose(hFind);
 }
 
-void FileMap::scanTextureFolder(const std::string& path, int modIndex)
+void FileMap::scanTextureFolder(const string& srcPath, int modIndex)
 {
 	WIN32_FIND_DATAA data;
-	auto searchPath = path + "\\*";
-	auto hFind = FindFirstFileA(searchPath.c_str(), &data);
+	char path[MAX_PATH];
+	snprintf(path, sizeof(path), "%s\\*", srcPath.c_str());
+	auto hFind = FindFirstFileA(path, &data);
 
-	auto lower = path;
+	string lower = srcPath;
 	transform(lower.begin(), lower.end(), lower.begin(), tolower);
 	std::vector<TexPackEntry> entries;
 
@@ -235,13 +233,14 @@ void FileMap::scanTextureFolder(const std::string& path, int modIndex)
 		for (const auto& i : entries)
 		{
 			auto name = i.name;
+			// Remove the file extension.
 			auto dot = name.find('.');
-			name = name.substr(0, dot);
+			name.resize(dot);
 
 			auto original = "system\\" + name + ".pvr";
 			transform(original.begin(), original.end(), original.begin(), tolower);
 
-			auto index_path = path + "\\index.txt";
+			auto index_path = srcPath + "\\index.txt";
 			transform(index_path.begin(), index_path.end(), index_path.begin(), tolower);
 
 			m_fileMap[original] = { index_path, modIndex };
@@ -264,14 +263,14 @@ void FileMap::scanTextureFolder(const std::string& path, int modIndex)
 			continue;
 		}
 
-		auto fileName = string(data.cFileName);
+		string fileName = string(data.cFileName);
 
 		if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		{
-			auto original = "system\\" + fileName + ".pvm";
+			string original = "system\\" + fileName + ".pvm";
 			transform(original.begin(), original.end(), original.begin(), ::tolower);
 
-			auto texPack = path + "\\" + fileName;
+			string texPack = srcPath + "\\" + fileName;
 			transform(texPack.begin(), texPack.end(), texPack.begin(), ::tolower);
 
 			// Since we don't attempt to parse this file, make sure it exists
@@ -283,7 +282,7 @@ void FileMap::scanTextureFolder(const std::string& path, int modIndex)
 		}
 		else
 		{
-			auto ext = GetExtension(fileName);
+			string ext = GetExtension(fileName);
 			transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
 			if (ext != "pvmx")
@@ -291,13 +290,13 @@ void FileMap::scanTextureFolder(const std::string& path, int modIndex)
 				continue;
 			}
 
-			auto noExt = fileName;
+			string noExt = fileName;
 			StripExtension(noExt);
 
-			auto original = "system\\" + noExt + ".pvm";
+			string original = "system\\" + noExt + ".pvm";
 			transform(original.begin(), original.end(), original.begin(), ::tolower);
 
-			auto texPack = path + "\\" + fileName;
+			string texPack = srcPath + "\\" + fileName;
 			transform(texPack.begin(), texPack.end(), texPack.begin(), ::tolower);
 			
 			m_fileMap[original] = { texPack, modIndex };
@@ -348,10 +347,10 @@ const char *FileMap::replaceFile(const char *lpFileName) const
 }
 
 /**
-* Get the index of the mod that replaced a given file.
-* @param lpFileName Filename.
-* @return Index of the mod that replaced a file, or 0 if no mod replaced it.
-*/
+ * Get the index of the mod that replaced a given file.
+ * @param lpFileName Filename.
+ * @return Index of the mod that replaced a file, or 0 if no mod replaced it.
+ */
 int FileMap::getModIndex(const char *lpFileName) const
 {
 	// Check if the normalized filename is in the file replacement map.

--- a/SADXModLoader/FileMap.hpp
+++ b/SADXModLoader/FileMap.hpp
@@ -65,10 +65,10 @@ class FileMap
 
 		/**
 		 * Scans a texture pack folder for 
-		 * @param path The path to the "textures" folder to scan.
+		 * @param srcPath The path to the "textures" folder to scan.
 		 * @param modIndex Index of the current mod.
 		 */
-		void scanTextureFolder(const std::string& path, int modIndex);
+		void scanTextureFolder(const std::string& srcPath, int modIndex);
 
 	protected:
 		/**

--- a/SADXModLoader/FileReplacement.cpp
+++ b/SADXModLoader/FileReplacement.cpp
@@ -17,7 +17,7 @@ FileMap sadx_fileMap;
 * @param hTemplateFile
 * @return
 */
-HANDLE __stdcall MyCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)
+HANDLE WINAPI MyCreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)
 {
 	return CreateFileA(sadx_fileMap.replaceFile(lpFileName), dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
 }

--- a/SADXModLoader/FileSystem.cpp
+++ b/SADXModLoader/FileSystem.cpp
@@ -1,5 +1,8 @@
 #include "stdafx.h"
 #include <windows.h>
+
+#include <cassert>
+
 #include <string>
 using std::string;
 using std::wstring;
@@ -99,4 +102,35 @@ string GetExtension(const string& path, bool includeDot)
 	}
 
 	return path.substr(dot);
+}
+
+/**
+ * Replace the extension of the specified filename.
+ * @param filename	[in/out] Filename.
+ * @param ext		[in] New extension, with leading dot.
+ */
+void ReplaceFileExtension(string &filename, const char *ext)
+{
+	assert(ext != nullptr);
+
+	// Find the last '.'.
+	size_t dot = filename.find_last_of('.');
+	if (dot == string::npos)
+	{
+		// No dot; no extension.
+		return;
+	}
+
+	// Find the last '/' or '\\'.
+	size_t bs = filename.find_last_of("/\\");
+	if (bs != string::npos && bs > dot)
+	{
+		// Dot is before the last slash.
+		// No extension.
+		return;
+	}
+
+	// Resize to the dot, then add ext.
+	filename.resize(dot+1);
+	filename.append(ext);
 }

--- a/SADXModLoader/FileSystem.cpp
+++ b/SADXModLoader/FileSystem.cpp
@@ -55,8 +55,7 @@ string GetDirectory(const string& path)
 		return string();
 	}
 
-	result = path.substr(last);
-	return result;
+	return path.substr(last);
 }
 
 string GetBaseName(const string& path)
@@ -74,7 +73,7 @@ string GetBaseName(const string& path)
 
 	auto last = slash - 1;
 	slash = path.find_last_of("/\\", last);
-	return (!slash || slash == npos) ? string() : path.substr(slash + 1, last - slash);
+	return (!slash || slash == string::npos) ? string() : path.substr(slash + 1, last - slash);
 }
 
 void StripExtension(string& path)

--- a/SADXModLoader/FileSystem.cpp
+++ b/SADXModLoader/FileSystem.cpp
@@ -1,127 +1,97 @@
 #include "stdafx.h"
-#include <Windows.h>
+#include <windows.h>
 #include <string>
-#include <shlwapi.h>
+using std::string;
+using std::wstring;
 
-bool Exists(const std::wstring& path)
+bool Exists(const wstring& path)
 {
-	return PathFileExistsW(path.c_str()) != 0;
+	return GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES;
 }
-bool Exists(const std::string& path)
+bool Exists(const string& path)
 {
-	return PathFileExistsA(path.c_str()) != 0;
-}
-
-bool IsDirectory(const std::wstring& path)
-{
-	return PathIsDirectoryW(path.c_str()) != 0;
-}
-bool IsDirectory(const std::string& path)
-{
-	return PathIsDirectoryA(path.c_str()) != 0;
+	return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
 }
 
-bool IsFile(const std::wstring& path)
+bool IsDirectory(const wstring& path)
 {
-	return !IsDirectory(path);
+	const DWORD attrs = GetFileAttributesW(path.c_str());
+	return (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY));
 }
-bool IsFile(const std::string& path)
+bool IsDirectory(const string& path)
 {
-	return !IsDirectory(path);
+	const DWORD attrs = GetFileAttributesA(path.c_str());
+	return (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY));
 }
 
-std::string GetDirectory(const std::string& path)
+bool IsFile(const wstring& path)
 {
-	std::string result;
-	auto npos = path.npos;
+	const DWORD attrs = GetFileAttributesW(path.c_str());
+	return (attrs != INVALID_FILE_ATTRIBUTES && !(attrs & FILE_ATTRIBUTE_DIRECTORY));
+}
+bool IsFile(const string& path)
+{
+	const DWORD attrs = GetFileAttributesA(path.c_str());
+	return (attrs != INVALID_FILE_ATTRIBUTES && !(attrs & FILE_ATTRIBUTE_DIRECTORY));
+}
 
-	auto slash = path.find_last_of('\\');
-	if (slash == npos)
+string GetDirectory(const string& path)
+{
+	auto slash = path.find_last_of("/\\");
+	if (slash == string::npos)
 	{
-		slash = path.find_last_of('/');
-
-		if (slash == npos)
-		{
-			result = "";
-			return result;
-		}
+		return string();
 	}
 
 	if (slash != path.size() - 1)
 	{
-		result = path.substr(0, slash);
-		return result;
+		return path.substr(0, slash);
 	}
 
 	auto last = slash;
-
-	slash = path.find_last_of('\\', last);
-	if (slash == npos)
+	slash = path.find_last_of("/\\", last);
+	if (slash == string::npos)
 	{
-		slash = path.find_last_of('/', last);
-	}
-
-	if (slash == npos)
-	{
-		result = "";
-		return result;
+		return string();
 	}
 
 	result = path.substr(last);
 	return result;
 }
 
-std::string GetBaseName(const std::string& path)
+string GetBaseName(const string& path)
 {
-	std::string result;
-	auto npos = path.npos;
-
-	auto slash = path.find_last_of('\\');
-	if (slash == npos)
+	auto slash = path.find_last_of("/\\");
+	if (slash == string::npos)
 	{
-		slash = path.find_last_of('/');
-		if (slash == npos)
-		{
-			result = path;
-			return result;
-		}
+		return path;
 	}
 
 	if (slash != path.size() - 1)
 	{
-		result = path.substr(++slash);
-		return result;
+		return path.substr(slash + 1);
 	}
 
 	auto last = slash - 1;
-
-	slash = path.find_last_of('\\', last);
-	if (slash == npos)
-	{
-		slash = path.find_last_of('/', last);
-	}
-
-	result = (!slash || slash == npos) ? "" : path.substr(slash + 1, last - slash);
-	return result;
+	slash = path.find_last_of("/\\", last);
+	return (!slash || slash == npos) ? string() : path.substr(slash + 1, last - slash);
 }
 
-void StripExtension(std::string& path)
+void StripExtension(string& path)
 {
 	auto dot = path.find('.');
-	if (dot == path.npos)
+	if (dot != string::npos)
 	{
-		return;
+		path.resize(dot);
 	}
-
-	path = path.substr(0, dot);
 }
 
-std::string GetExtension(const std::string& path, bool includeDot)
+string GetExtension(const string& path, bool includeDot)
 {
 	auto dot = path.find('.');
-	if (dot == path.npos)
+	if (dot == string::npos)
 	{
-		return "";
+		return string();
 	}
 
 	if (!includeDot)

--- a/SADXModLoader/FileSystem.h
+++ b/SADXModLoader/FileSystem.h
@@ -32,3 +32,10 @@ std::string GetDirectory(const std::string& path);
 std::string GetBaseName(const std::string& path);
 void StripExtension(std::string& path);
 std::string GetExtension(const std::string& path, bool includeDot = false);
+
+/**
+ * Replace the extension of the specified filename.
+ * @param filename	[in/out] Filename.
+ * @param ext		[in] New extension, with leading dot.
+ */
+void ReplaceFileExtension(std::string &filename, const char *ext);

--- a/SADXModLoader/MediaFns.cpp
+++ b/SADXModLoader/MediaFns.cpp
@@ -10,11 +10,8 @@
 
 #include "bass_vgmstream.h"
 
-#include <Shlwapi.h>
-#include <forward_list>
 #include <string>
 #include <vector>
-using std::forward_list;
 using std::string;
 using std::vector;
 
@@ -302,17 +299,31 @@ struc_64 *LoadSoundPack(const char *path, int bank)
 {
 	char filename[MAX_PATH];
 	snprintf(filename, sizeof(filename), "%sindex.txt", path);
-	const char *pidxpath = filename;
-	pidxpath = sadx_fileMap.replaceFile(pidxpath);
-	if (!FileExists(pidxpath))
-		return nullptr;
-	char path2[MAX_PATH];
-	strncpy(path2, pidxpath, sizeof(path2));
-	PathRemoveFileSpecA(path2);
-	PathAddBackslashA(path2);
+	const char *pidxpath = sadx_fileMap.replaceFile(filename);
 	FILE *f = fopen(pidxpath, "r");
 	if (!f)
 		return nullptr;
+
+	char path2[MAX_PATH];
+	strncpy(path2, pidxpath, sizeof(path2));
+	// Find the last slash or backslash and remove everything after it.
+	// (Equivalent to PathRemoveFileSpecA())
+	char *bs = strrchr(path2, '\\');
+	char *slash = strrchr(path2, '/');	// just in case...
+	if (slash > bs)
+		bs = slash;
+	if (bs)
+	{
+		bs[1] = 0;
+	}
+	else
+	{
+		// No backslash is not good.
+		// Add a backslash at the end just in case.
+		strcat_s(path2, sizeof(path2), "\\");
+	}
+
+	// Load the sound files.
 	vector<DATEntry> entries;
 	char line[MAX_PATH];
 	while (!feof(f))
@@ -320,6 +331,7 @@ struc_64 *LoadSoundPack(const char *path, int bank)
 		if (!fgets(line, sizeof(line), f))
 		{
 			if (feof(f)) break;
+			// Read error.
 			for (size_t i = 0; i < entries.size(); i++)
 			{
 				delete[] entries[i].NameOffset;
@@ -328,17 +340,21 @@ struc_64 *LoadSoundPack(const char *path, int bank)
 			fclose(f);
 			return nullptr;
 		}
+
+		// Remove trailing newlines.
 		int linelen = strnlen(line, sizeof(line));
-		if (linelen > 0 && line[linelen - 1] == '\n')
+		while (linelen > 0 && (line[linelen-1] == '\n' || line[linelen-1] == '\r'))
+		{
 			line[--linelen] = 0;
+		}
 		if (linelen == 0)
 			continue;
+
 		snprintf(filename, sizeof(filename), "%s%s", path2, line);
-		if (!FileExists(filename))
-			return nullptr;
 		FILE *f2 = fopen(filename, "rb");
 		if (!f2)
 		{
+			// Unable to open a referenced file.
 			for (size_t i = 0; i < entries.size(); i++)
 			{
 				delete[] entries[i].NameOffset;
@@ -347,9 +363,10 @@ struc_64 *LoadSoundPack(const char *path, int bank)
 			fclose(f);
 			return nullptr;
 		}
+
 		DATEntry ent;
 		ent.NameOffset = new char[14];
-		snprintf(ent.NameOffset, 14, "B%02d_00_%02d.wav", bank, entries.size());
+		snprintf(ent.NameOffset, 14, "B%02d_00_%02u.wav", bank, entries.size());
 		fseek(f2, 0, SEEK_END);
 		ent.DataLength = (int)ftell(f2);
 		ent.DataOffset = new char[ent.DataLength];
@@ -358,6 +375,9 @@ struc_64 *LoadSoundPack(const char *path, int bank)
 		fclose(f2);
 		entries.push_back(ent);
 	}
+	fclose(f);
+
+	// Convert the sound pack to the format expected by SADX in memory.
 	int size = 28;
 	size += entries.size() * sizeof(DATEntry);
 	size += entries.size() * 14;

--- a/SADXModLoader/MediaFns.cpp
+++ b/SADXModLoader/MediaFns.cpp
@@ -306,6 +306,7 @@ struc_64 *LoadSoundPack(const char *path, int bank)
 
 	char path2[MAX_PATH];
 	strncpy(path2, pidxpath, sizeof(path2));
+	path2[MAX_PATH-1] = 0;
 	// Find the last slash or backslash and remove everything after it.
 	// (Equivalent to PathRemoveFileSpecA())
 	char *bs = strrchr(path2, '\\');

--- a/SADXModLoader/MediaFns.hpp
+++ b/SADXModLoader/MediaFns.hpp
@@ -68,6 +68,7 @@ struct struc_64
 	char *Filename;
 	void *DATFile;
 	int NumSFX;
+	// Technically an array of DATEntries.
 	DATEntry DATEntries;
 };
 #pragma pack(pop)

--- a/SADXModLoader/SADXModLoader.rc
+++ b/SADXModLoader/SADXModLoader.rc
@@ -4,6 +4,16 @@
  */
 
 #include "windows.h"
+#include "resource.h"
+
+/** Accelerator table. **/
+
+IDR_ACCEL_WRAPPER_WINDOW ACCELERATORS
+BEGIN
+	VK_RETURN,	ID_FULLSCREEN,	VIRTKEY, ALT
+END
+
+/** Application version. **/
 
 // git version
 #include "git.h"
@@ -21,7 +31,6 @@
 #define Win32_RC_FileVersion VERSION_STRING
 #endif /* MODLOADER_GIT_VERSION */
 
-// Application Version
 VS_VERSION_INFO VERSIONINFO
 	FILEVERSION VERSION_WIN32
 	PRODUCTVERSION VERSION_WIN32

--- a/SADXModLoader/TextureReplacement.cpp
+++ b/SADXModLoader/TextureReplacement.cpp
@@ -592,14 +592,14 @@ static bool TryTexturePack(const char* filename, NJS_TEXLIST* texlist)
 
 	// Since the filename can be passed in with or without an extension, first
 	// we try getting a replacement with the filename as-is (with SYSTEM\ prepended).
-	auto system_path = "SYSTEM\\" + filename_str;
+	const string system_path = "SYSTEM\\" + filename_str;
 	string replaced = sadx_fileMap.replaceFile(system_path.c_str());
 
 	// But if that failed, we can assume that it was given without an extension
 	// (which is the intended use) and append one before trying again.
-	auto system_path_ext = system_path + ".PVM";
 	if (!Exists(replaced))
 	{
+		const string system_path_ext = system_path + ".PVM";
 		replaced = sadx_fileMap.replaceFile(system_path_ext.c_str());
 	}
 

--- a/SADXModLoader/TextureReplacement.cpp
+++ b/SADXModLoader/TextureReplacement.cpp
@@ -705,7 +705,7 @@ static bool ReplacePVR(const string& filename, NJS_TEXMEMLIST** tex)
 	string _filename = filename;
 	transform(_filename.begin(), _filename.end(), _filename.begin(), tolower);
 
-	auto file_path = "system\\" + _filename + ".pvr";
+	string file_path = "system\\" + _filename + ".pvr";
 	string index_path = sadx_fileMap.replaceFile(file_path.c_str());
 
 	if (index_path == file_path)
@@ -730,20 +730,24 @@ static bool ReplacePVR(const string& filename, NJS_TEXMEMLIST** tex)
 
 	for (const auto& i : entries)
 	{
-		auto name = i.name;
-
-		replace(name.begin(), name.end(), '/', '\\');
-		auto npos = name.npos;
+		const auto &name = i.name;
 
 		auto dot = name.find_last_of('.');
-
-		if (dot == npos)
+		if (dot == string::npos)
 		{
 			continue;
 		}
 
-		auto slash = name.find_last_of('\\');
-		slash = slash == npos ? 0 : ++slash;
+		// Get the filename portion of the path.
+		auto slash = name.find_last_of("/\\");
+		slash = (slash == string::npos ? 0 : (slash+1));
+		if (slash > dot)
+		{
+			// Should not happen, but this usually means the
+			// dot is part of some other path component, not
+			// the filename.
+			continue;
+		}
 
 		string texture_name = name.substr(slash, dot - slash);
 		transform(texture_name.begin(), texture_name.end(), texture_name.begin(), tolower);

--- a/SADXModLoader/UiScale.cpp
+++ b/SADXModLoader/UiScale.cpp
@@ -483,16 +483,18 @@ void uiscale::Initialize()
 template<typename T, typename... Args>
 void ScaleTrampoline(Uint8 align, bool is_background, const T&, const Trampoline* t, Args... args)
 {
+	T *const pfn = reinterpret_cast<T*>(t->Target());
+
 	if (is_background && bg_fill == FillMode::Stretch)
 	{
 		ScaleDisable();
-		((T*)t->Target())(args...);
+		pfn(args...);
 		ScaleEnable();
 		return;
 	}
 
 	ScalePush(align, is_background);
-	((T*)t->Target())(args...);
+	pfn(args...);
 	ScalePop();
 }
 
@@ -509,16 +511,18 @@ void ScaleTrampoline(Uint8 align, bool is_background, const T&, const Trampoline
 template<typename R, typename T, typename... Args>
 R ScaleTrampoline(Uint8 align, bool is_background, const T&, const Trampoline* t, Args... args)
 {
+	T *const pfn = reinterpret_cast<T*>(t->Target());
+
 	if (is_background && bg_fill == FillMode::Stretch)
 	{
 		ScaleDisable();
-		R result = ((T*)t->Target())(args...);
+		R result = pfn(args...);
 		ScaleEnable();
 		return result;
 	}
 
 	ScalePush(align, is_background);
-	R result = ((T*)t->Target())(args...);
+	R result = pfn(args...);
 	ScalePop();
 	return result;
 }

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1267,7 +1267,7 @@ static uint8_t ParseCharacterFlags(const string &str)
 {
 	vector<string> strflags = split(str, ',');
 	uint8_t flag = 0;
-	for (auto iter = strflags.cbegin(); iter != strflags.cend(); iter++)
+	for (auto iter = strflags.cbegin(); iter != strflags.cend(); ++iter)
 	{
 		string s = trim(*iter);
 		transform(s.begin(), s.end(), s.begin(), ::tolower);
@@ -1428,7 +1428,7 @@ static void ProcessStartPosINI(const IniGroup *group, const wstring &mod_dir)
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
 	const IniFile *startposdata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
 	vector<StartPosition> poss;
-	for (auto iter = startposdata->cbegin(); iter != startposdata->cend(); iter++)
+	for (auto iter = startposdata->cbegin(); iter != startposdata->cend(); ++iter)
 	{
 		if (iter->first.empty()) continue;
 		StartPosition pos;
@@ -1545,7 +1545,7 @@ static void ProcessFieldStartPosINI(const IniGroup *group, const wstring &mod_di
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
 	const IniFile *startposdata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
 	vector<FieldStartPosition> poss;
-	for (auto iter = startposdata->cbegin(); iter != startposdata->cend(); iter++)
+	for (auto iter = startposdata->cbegin(); iter != startposdata->cend(); ++iter)
 	{
 		if (iter->first.empty()) continue;
 		FieldStartPosition pos = { ParseLevelID(iter->first) };
@@ -2061,7 +2061,7 @@ static void LoadDLLLandTable(const wstring &path)
 {
 	LandTableInfo *info = new LandTableInfo(path);
 	auto labels = info->getlabels();
-	for (auto iter = labels->cbegin(); iter != labels->cend(); iter++)
+	for (auto iter = labels->cbegin(); iter != labels->cend(); ++iter)
 		dlllabels[iter->first] = iter->second;
 }
 
@@ -2069,7 +2069,7 @@ static void LoadDLLModel(const wstring &path)
 {
 	ModelInfo *info = new ModelInfo(path);
 	auto labels = info->getlabels();
-	for (auto iter = labels->cbegin(); iter != labels->cend(); iter++)
+	for (auto iter = labels->cbegin(); iter != labels->cend(); ++iter)
 		dlllabels[iter->first] = iter->second;
 }
 
@@ -2650,7 +2650,7 @@ static void __cdecl InitMods()
 		if (modinfo->hasKeyNonEmpty("EXEData"))
 		{
 			IniFile *exedata = new IniFile(mod_dir + L'\\' + modinfo->getWString("EXEData"));
-			for (auto iter = exedata->cbegin(); iter != exedata->cend(); iter++)
+			for (auto iter = exedata->cbegin(); iter != exedata->cend(); ++iter)
 			{
 				IniGroup *group = iter->second;
 				auto type = exedatafuncmap.find(group->getString("type"));
@@ -2668,7 +2668,7 @@ static void __cdecl InitMods()
 				IniFile *dlldata = new IniFile(mod_dir + L'\\' + modinfo->getWString(dlldatakeys[j]));
 				dlllabels.clear();
 				const IniGroup *group = dlldata->getGroup("Files");
-				for (auto iter = group->cbegin(); iter != group->cend(); iter++)
+				for (auto iter = group->cbegin(); iter != group->cend(); ++iter)
 				{
 					auto type = dllfilefuncmap.find(split(iter->second, '|')[0]);
 					if (type != dllfilefuncmap.end())
@@ -2687,7 +2687,7 @@ static void __cdecl InitMods()
 				{
 					group = dlldata->getGroup("Exports");
 					dllexportcontainer exp;
-					for (auto iter = group->cbegin(); iter != group->cend(); iter++)
+					for (auto iter = group->cbegin(); iter != group->cend(); ++iter)
 					{
 						dllexportinfo inf;
 						inf.address = GetProcAddress(dllhandle, iter->first.c_str());

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1881,7 +1881,7 @@ static void ProcessDeathZoneINI(const IniGroup *group, const wstring &mod_dir)
 		if (!dzdata->hasGroup(key)) break;
 		uint8_t flag = ParseCharacterFlags(dzdata->getString(key, "Flags"));
 		wchar_t wkey[8];
-		_snwprintf(wkey, LengthOfArray(wkey), L"%u", i);
+		swprintf(wkey, LengthOfArray(wkey), L"%u", i);
 		ModelInfo *dzmdl = new ModelInfo(dzpath + L"\\" + wkey + L".sa1mdl");
 		DeathZone dz = { flag, dzmdl->getmodel() };
 		deathzones.push_back(dz);
@@ -1945,7 +1945,7 @@ static void ProcessLevelPathListINI(const IniGroup *group, const wstring &mod_di
 		vector<LoopHead *> paths;
 		for (unsigned int i = 0; i < 999; i++)
 		{
-			_snwprintf(buf, levelpath.size() + 2, levelpath.c_str(), i);
+			swprintf(buf, levelpath.size() + 2, levelpath.c_str(), i);
 
 			if (!Exists(buf))
 				break;

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -172,9 +172,9 @@ static int __cdecl SADXDebugOutput(const char *Format, ...)
 	va_start(ap, Format);
 	int result = vsnprintf(nullptr, 0, Format, ap) + 1;
 	va_end(ap);
-	char *buf = new char[result];
+	char *buf = new char[result+1];
 	va_start(ap, Format);
-	result = vsnprintf(buf, result, Format, ap);
+	result = vsnprintf(buf, result+1, Format, ap);
 	va_end(ap);
 
 	// Console output.
@@ -189,8 +189,13 @@ static int __cdecl SADXDebugOutput(const char *Format, ...)
 	if (dbgScreen)
 	{
 		message msg = { buf };
-		if (msg.text[msg.text.length() - 1] == '\n')
-			msg.text = msg.text.substr(0, msg.text.length() - 1);
+		// Remove trailing newlines if present.
+		while (!msg.text.empty() &&
+			(msg.text[msg.text.size()-1] == '\n' ||
+			 msg.text[msg.text.size()-1] == '\r'))
+		{
+			msg.text.resize(msg.text.size()-1);
+		}
 		msgqueue.push_back(msg);
 	}
 

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+#include <cassert>
+
 #include <deque>
 #include <fstream>
 #include <memory>
@@ -1362,6 +1364,9 @@ static string UnescapeNewlines(const string &str)
 static void ParseVertex(const string &str, NJS_VECTOR &vert)
 {
 	vector<string> vals = split(str, ',');
+	assert(vals.size() == 3);
+	if (vals.size() < 3)
+		return;
 	vert.x = (float)strtod(vals[0].c_str(), nullptr);
 	vert.y = (float)strtod(vals[1].c_str(), nullptr);
 	vert.z = (float)strtod(vals[2].c_str(), nullptr);
@@ -1370,6 +1375,9 @@ static void ParseVertex(const string &str, NJS_VECTOR &vert)
 static void ParseRotation(const string str, Rotation &rot)
 {
 	vector<string> vals = split(str, ',');
+	assert(vals.size() == 3);
+	if (vals.size() < 3)
+		return;
 	rot.x = (int)strtol(vals[0].c_str(), nullptr, 16);
 	rot.y = (int)strtol(vals[1].c_str(), nullptr, 16);
 	rot.z = (int)strtol(vals[2].c_str(), nullptr, 16);

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1934,7 +1934,7 @@ static void ProcessLevelPathListINI(const IniGroup *group, const wstring &mod_di
 		uint16_t levelact;
 		try
 		{
-			levelact = ParseLevelAndActID(UTF16toMBS(wstring(data.cFileName), CP_UTF8));
+			levelact = ParseLevelAndActID(UTF16toMBS(data.cFileName, CP_UTF8));
 		}
 		catch (...)
 		{

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -2123,7 +2123,8 @@ static void ProcessStageLightDataListINI(const IniGroup *group, const wstring &m
 	ProcessPointerList(group->getString("pointer"), list);
 }
 
-static const unordered_map<string, void(__cdecl *)(const IniGroup *, const wstring &)> exedatafuncmap = {
+typedef void (__cdecl *exedatafunc_t)(const IniGroup *group, const wstring &mod_dir);
+static const unordered_map<string, exedatafunc_t> exedatafuncmap = {
 	{ "landtable", ProcessLandTableINI },
 	{ "model", ProcessModelINI },
 	{ "basicdxmodel", ProcessModelINI },
@@ -2176,7 +2177,8 @@ static void LoadDLLAnimation(const wstring &path)
 	dlllabels[info->getlabel()] = info->getmotion();
 }
 
-static const unordered_map<string, void(__cdecl *)(const wstring &)> dllfilefuncmap = {
+typedef void (__cdecl *dllfilefunc_t)(const wstring &path);
+static const unordered_map<string, dllfilefunc_t> dllfilefuncmap = {
 	{ "landtable", LoadDLLLandTable },
 	{ "model", LoadDLLModel },
 	{ "basicdxmodel", LoadDLLModel },
@@ -2225,7 +2227,8 @@ static void ProcessActionArrayDLL(const IniGroup *group, void *exp)
 		act->motion = (NJS_MOTION *)dlllabels[group->getString("Label")];
 }
 
-static const unordered_map<string, void(__cdecl *)(const IniGroup *, void *)> dlldatafuncmap = {
+typedef void (__cdecl *dlldatafunc_t)(const IniGroup *group, void *exp);
+static const unordered_map<string, dlldatafunc_t> dlldatafuncmap = {
 	{ "landtable", ProcessLandTableDLL },
 	{ "landtablearray", ProcessLandTableArrayDLL },
 	{ "model", ProcessModelDLL },

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1394,7 +1394,11 @@ static void ProcessPointerList(const string &list, T *item)
 static void ProcessLandTableINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	LandTable *landtable = (new LandTableInfo(mod_dir + L'\\' + group->getWString("filename")))->getlandtable();
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	LandTableInfo *const landtableinfo = new LandTableInfo(filename);
+	LandTable *const landtable = landtableinfo->getlandtable();
 	ProcessPointerList(group->getString("pointer"), landtable);
 }
 
@@ -1402,7 +1406,10 @@ static unordered_map<string, NJS_OBJECT *> inimodels;
 static void ProcessModelINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	ModelInfo *mdlinf = new ModelInfo(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	ModelInfo *const mdlinf = new ModelInfo(filename);
 	NJS_OBJECT *model = mdlinf->getmodel();
 	inimodels[mdlinf->getlabel(model)] = model;
 	ProcessPointerList(group->getString("pointer"), model);
@@ -1411,8 +1418,12 @@ static void ProcessModelINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessActionINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
 	NJS_ACTION *action = new NJS_ACTION;
-	action->motion = (new AnimationFile(mod_dir + L'\\' + group->getWString("filename")))->getmotion();
+	AnimationFile *const animationFile = new AnimationFile(filename);
+	action->motion = animationFile->getmotion();
 	action->object = inimodels.find(group->getString("model"))->second;
 	ProcessPointerList(group->getString("pointer"), action);
 }
@@ -1420,7 +1431,11 @@ static void ProcessActionINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessAnimationINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	NJS_MOTION *animation = (new AnimationFile(mod_dir + L'\\' + group->getWString("filename")))->getmotion();
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	AnimationFile *const animationFile = new AnimationFile(filename);
+	NJS_MOTION *animation = animationFile->getmotion();
 	ProcessPointerList(group->getString("pointer"), animation);
 }
 

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1949,7 +1949,8 @@ static void ProcessDeathZoneINI(const IniGroup *group, const wstring &mod_dir)
 		ModelInfo *dzmdl = new ModelInfo(dzpath);
 		DeathZone dz = { flag, dzmdl->getmodel() };
 		deathzones.push_back(dz);
-		// FIXME: dzmdl is never deleted?
+		// NOTE: dzmdl is not deleted because NJS_OBJECT
+		// points to allocated memory in the ModelInfo.
 	}
 
 	DeathZone *newlist = new DeathZone[deathzones.size() + 1];

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -394,30 +394,33 @@ static void Direct3D_DeviceLost()
 
 			if (++tries >= retry_count)
 			{
-				DWORD mb_result;
-
+				const wchar_t *errstr;
 				switch (reset)
 				{
 					default:
 					case D3DERR_INVALIDCALL:
-						mb_result = MessageBox(hWnd,
-							L"The following error occurred while trying to reset DirectX:\nD3DERR_INVALIDCALL\n\nPress Cancel to exit, or press Retry to try again.",
-							L"Direct3D Reset failed", MB_RETRYCANCEL | MB_ICONERROR);
+						errstr = L"D3DERR_INVALIDCALL";
 						break;
-
 					case D3DERR_OUTOFVIDEOMEMORY:
-						mb_result = MessageBox(hWnd,
-							L"The following error occurred while trying to reset DirectX:\nD3DERR_OUTOFVIDEOMEMORY\n\nPress Cancel to exit, or press Retry to try again.",
-							L"Direct3D Reset failed", MB_RETRYCANCEL | MB_ICONERROR);
+						errstr = L"D3DERR_OUTOFVIDEOMEMORY";
 						break;
-
 					case E_OUTOFMEMORY:
-						mb_result = MessageBox(hWnd,
-							L"The following error occurred while trying to reset DirectX:\nE_OUTOFMEMORY\n\nPress Cancel to exit, or press Retry to try again.",
-							L"Direct3D Reset failed", MB_RETRYCANCEL | MB_ICONERROR);
+						errstr = L"E_OUTOFMEMORY";
+						break;
+					case D3DERR_DEVICELOST:
+						errstr = L"D3DERR_DEVICELOST";
+						break;
+					case D3DERR_DRIVERINTERNALERROR:
+						errstr = L"D3DERR_DRIVERINTERNALERROR";
 						break;
 				}
 
+				wchar_t wbuf[256];
+				swprintf(wbuf, LengthOfArray(wbuf),
+					L"The following error occurred while trying to reset DirectX:\n\n%s\n\n"
+					L"Press Cancel to exit, or press Retry to try again.", errstr);
+				DWORD mb_result = MessageBox(hWnd, wbuf,
+					L"Direct3D Reset failed", MB_RETRYCANCEL | MB_ICONERROR);
 				if (mb_result == IDRETRY)
 				{
 					tries = 0;

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1397,7 +1397,10 @@ static void ProcessAnimationINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessObjListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	const IniFile *objlistdata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const objlistdata = new IniFile(filename);
 	vector<ObjectListEntry> objs;
 	for (unsigned int i = 0; i < 999; i++)
 	{
@@ -1426,7 +1429,10 @@ static void ProcessObjListINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessStartPosINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	const IniFile *startposdata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const startposdata = new IniFile(filename);
 	vector<StartPosition> poss;
 	for (auto iter = startposdata->cbegin(); iter != startposdata->cend(); ++iter)
 	{
@@ -1468,7 +1474,10 @@ static vector<PVMEntry> ProcessTexListINI_Internal(const IniFile *texlistdata)
 static void ProcessTexListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	const IniFile *texlistdata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const texlistdata = new IniFile(filename);
 	vector<PVMEntry> texs = ProcessTexListINI_Internal(texlistdata);
 	delete texlistdata;
 	auto numents = texs.size();
@@ -1481,7 +1490,10 @@ static void ProcessTexListINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessLevelTexListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	const IniFile *texlistdata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const texlistdata = new IniFile(filename);
 	vector<PVMEntry> texs = ProcessTexListINI_Internal(texlistdata);
 	auto numents = texs.size();
 	PVMEntry *list = new PVMEntry[numents];
@@ -1543,7 +1555,10 @@ static void ProcessBossLevelListINI(const IniGroup *group, const wstring &mod_di
 static void ProcessFieldStartPosINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	const IniFile *startposdata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const startposdata = new IniFile(filename);
 	vector<FieldStartPosition> poss;
 	for (auto iter = startposdata->cbegin(); iter != startposdata->cend(); ++iter)
 	{
@@ -1566,7 +1581,10 @@ static void ProcessFieldStartPosINI(const IniGroup *group, const wstring &mod_di
 static void ProcessSoundTestListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("address")) return;
-	const IniFile *inidata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const inidata = new IniFile(filename);
 	vector<SoundTestEntry> sounds;
 	for (unsigned int i = 0; i < 999; i++)
 	{
@@ -1590,7 +1608,10 @@ static void ProcessSoundTestListINI(const IniGroup *group, const wstring &mod_di
 static void ProcessMusicListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("address")) return;
-	const IniFile *inidata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const inidata = new IniFile(filename);
 	vector<MusicInfo> songs;
 	for (unsigned int i = 0; i < 999; i++)
 	{
@@ -1611,7 +1632,10 @@ static void ProcessMusicListINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessSoundListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("address")) return;
-	const IniFile *inidata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const inidata = new IniFile(filename);
 	vector<SoundFileInfo> sounds;
 	for (unsigned int i = 0; i < 999; i++)
 	{
@@ -1632,7 +1656,7 @@ static void ProcessSoundListINI(const IniGroup *group, const wstring &mod_dir)
 	list->Count = (int)numents;
 }
 
-static vector<char *> ProcessStringArrayINI_Internal(const wstring &filename, uint8_t language)
+static vector<char *> ProcessStringArrayINI_Internal(const wchar_t *filename, uint8_t language)
 {
 	ifstream fstr(filename);
 	vector<char *> strs;
@@ -1650,7 +1674,10 @@ static vector<char *> ProcessStringArrayINI_Internal(const wstring &filename, ui
 static void ProcessStringArrayINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("address")) return;
-	vector<char *> strs = ProcessStringArrayINI_Internal(mod_dir + L'\\' + group->getWString("filename"),
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	vector<char *> strs = ProcessStringArrayINI_Internal(filename,
 		ParseLanguage(group->getString("language")));
 	auto numents = strs.size();
 	char **list = (char**)(group->getIntRadix("address", 16) + 0x400000);;
@@ -1660,7 +1687,10 @@ static void ProcessStringArrayINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessNextLevelListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	const IniFile *inidata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const inidata = new IniFile(filename);
 	vector<NextLevelData> ents;
 	for (unsigned int i = 0; i < 999; i++)
 	{
@@ -1695,10 +1725,13 @@ static void ProcessCutsceneTextINI(const IniGroup *group, const wstring &mod_dir
 	char ***addr = (char ***)group->getIntRadix("address", 16);
 	if (addr == nullptr) return;
 	addr = (char ***)((int)addr + 0x400000);
-	wstring pathbase = mod_dir + L'\\' + group->getWString("filename") + L'\\';
+	const wstring pathbase = mod_dir + L'\\' + group->getWString("filename") + L'\\';
 	for (unsigned int i = 0; i < LengthOfArray(languagenames); i++)
 	{
-		vector<char *> strs = ProcessStringArrayINI_Internal(pathbase + languagenames[i] + L".txt", i);
+		wchar_t filename[MAX_PATH];
+		swprintf(filename, LengthOfArray(filename), L"%s%s.txt",
+			pathbase.c_str(), languagenames[i]);
+		vector<char *> strs = ProcessStringArrayINI_Internal(filename, i);
 		auto numents = strs.size();
 		char **list = new char *[numents];
 		arrcpy(list, strs.data(), numents);
@@ -1713,15 +1746,16 @@ static void ProcessRecapScreenINI(const IniGroup *group, const wstring &mod_dir)
 	RecapScreen **addr = (RecapScreen **)group->getIntRadix("address", 16);
 	if (addr == nullptr) return;
 	addr = (RecapScreen **)((int)addr + 0x400000);
-	wstring pathbase = mod_dir + L'\\' + group->getWString("filename") + L'\\';
+	const wstring pathbase = mod_dir + L'\\' + group->getWString("filename") + L'\\';
 	for (unsigned int l = 0; l < LengthOfArray(languagenames); l++)
 	{
 		RecapScreen *list = new RecapScreen[length];
 		for (int i = 0; i < length; i++)
 		{
-			wchar_t wbuf[8];
-			swprintf(wbuf, LengthOfArray(wbuf), L"%d", i + 1);
-			const IniFile *inidata = new IniFile(pathbase + wbuf + L'\\' + languagenames[l] + L".ini");
+			wchar_t filename[MAX_PATH];
+			swprintf(filename, LengthOfArray(filename), L"%s%d\\%s.ini",
+				pathbase.c_str(), i + 1, languagenames[i]);
+			const IniFile *const inidata = new IniFile(filename);
 			vector<string> strs = split(inidata->getString("", "Text"), '\n');
 			auto numents = strs.size();
 			list[i].TextData = new char *[numents];
@@ -1742,15 +1776,16 @@ static void ProcessNPCTextINI(const IniGroup *group, const wstring &mod_dir)
 	HintText_Entry **addr = (HintText_Entry **)group->getIntRadix("address", 16);
 	if (addr == nullptr) return;
 	addr = (HintText_Entry **)((int)addr + 0x400000);
-	wstring pathbase = mod_dir + L'\\' + group->getWString("filename") + L'\\';
+	const wstring pathbase = mod_dir + L'\\' + group->getWString("filename") + L'\\';
 	for (unsigned int l = 0; l < LengthOfArray(languagenames); l++)
 	{
 		HintText_Entry *list = new HintText_Entry[length];
 		for (int i = 0; i < length; i++)
 		{
-			wchar_t wbuf[8];
-			swprintf(wbuf, LengthOfArray(wbuf), L"%d", i + 1);
-			const IniFile *inidata = new IniFile(pathbase + wbuf + L'\\' + languagenames[l] + L".ini");
+			wchar_t filename[MAX_PATH];
+			swprintf(filename, LengthOfArray(filename), L"%s%d\\%s.ini",
+				pathbase.c_str(), i + 1, languagenames[i]);
+			const IniFile *const inidata = new IniFile(filename);
 			vector<int16_t> props;
 			vector<HintText_Text> text;
 			for (unsigned int j = 0; j < 999; j++)
@@ -1840,7 +1875,10 @@ static void ProcessNPCTextINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessLevelClearFlagListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	ifstream fstr(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	ifstream fstr(filename);
 	vector<LevelClearFlagData> lvls;
 	while (fstr.good())
 	{
@@ -1866,13 +1904,16 @@ static void ProcessLevelClearFlagListINI(const IniGroup *group, const wstring &m
 static void ProcessDeathZoneINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	wstring dzinipath = mod_dir + L'\\' + group->getWString("filename");
-	IniFile *dzdata = new IniFile(dzinipath);
-	wchar_t *buf = new wchar_t[dzinipath.size() + 1];
-	wcsncpy(buf, dzinipath.c_str(), dzinipath.size());
-	PathRemoveFileSpec(buf);
-	wstring dzpath = buf;
-	delete[] buf;
+	wchar_t dzinipath[MAX_PATH];
+	swprintf(dzinipath, LengthOfArray(dzinipath), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const dzdata = new IniFile(dzinipath);
+
+	// Remove the filename portion of the path.
+	// NOTE: This might be a lower directory than mod_dir,
+	// since the filename can have subdirectories.
+	PathRemoveFileSpec(dzinipath);
+
 	vector<DeathZone> deathzones;
 	for (unsigned int i = 0; i < 999; i++)
 	{
@@ -1880,13 +1921,15 @@ static void ProcessDeathZoneINI(const IniGroup *group, const wstring &mod_dir)
 		snprintf(key, sizeof(key), "%u", i);
 		if (!dzdata->hasGroup(key)) break;
 		uint8_t flag = ParseCharacterFlags(dzdata->getString(key, "Flags"));
-		wchar_t wkey[8];
-		swprintf(wkey, LengthOfArray(wkey), L"%u", i);
-		ModelInfo *dzmdl = new ModelInfo(dzpath + L"\\" + wkey + L".sa1mdl");
+
+		wchar_t dzpath[MAX_PATH];
+		swprintf(dzpath, LengthOfArray(dzpath), L"%s\\%u.sa1mdl", dzinipath, i);
+		ModelInfo *dzmdl = new ModelInfo(dzpath);
 		DeathZone dz = { flag, dzmdl->getmodel() };
 		deathzones.push_back(dz);
+		// FIXME: dzmdl is never deleted?
 	}
-	delete dzdata;
+
 	DeathZone *newlist = new DeathZone[deathzones.size() + 1];
 	arrcpy(newlist, deathzones.data(), deathzones.size());
 	clrmem(&newlist[deathzones.size()]);
@@ -1900,7 +1943,11 @@ static void ProcessSkyboxScaleINI(const IniGroup *group, const wstring &mod_dir)
 	SkyboxScale **addr = (SkyboxScale **)group->getIntRadix("address", 16);
 	if (addr == nullptr) return;
 	addr = (SkyboxScale **)((int)addr + 0x400000);
-	const IniFile *inidata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const inidata = new IniFile(filename);
 	for (int i = 0; i < count; i++)
 	{
 		char key[8];
@@ -1910,7 +1957,7 @@ static void ProcessSkyboxScaleINI(const IniGroup *group, const wstring &mod_dir)
 			*addr++ = nullptr;
 			continue;
 		}
-		const IniGroup *entdata = inidata->getGroup(key);
+		const IniGroup *const entdata = inidata->getGroup(key);
 		SkyboxScale *entry = new SkyboxScale;
 		ParseVertex(entdata->getString("Far", "1,1,1"), entry->Far);
 		ParseVertex(entdata->getString("Normal", "1,1,1"), entry->Normal);
@@ -1923,10 +1970,12 @@ static void ProcessSkyboxScaleINI(const IniGroup *group, const wstring &mod_dir)
 static void ProcessLevelPathListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	wstring inipath = mod_dir + L'\\' + group->getWString("filename") + L'\\';
+	wchar_t inipath[MAX_PATH];
+	swprintf(inipath, LengthOfArray(inipath), L"%s\\%s\\",
+		mod_dir.c_str(), group->getWString("filename").c_str());
 	vector<PathDataPtr> pathlist;
 	WIN32_FIND_DATA data;
-	HANDLE hFind = FindFirstFileEx(inipath.c_str(), FindExInfoStandard, &data, FindExSearchLimitToDirectories, nullptr, 0);
+	HANDLE hFind = FindFirstFileEx(inipath, FindExInfoStandard, &data, FindExSearchLimitToDirectories, nullptr, 0);
 	if (hFind == INVALID_HANDLE_VALUE) return;
 	do
 	{
@@ -1940,17 +1989,17 @@ static void ProcessLevelPathListINI(const IniGroup *group, const wstring &mod_di
 		{
 			continue;
 		}
-		wstring levelpath = inipath + data.cFileName + L"\\%u.ini";
-		wchar_t *buf = new wchar_t[levelpath.size() + 2];
+
 		vector<LoopHead *> paths;
 		for (unsigned int i = 0; i < 999; i++)
 		{
-			swprintf(buf, levelpath.size() + 2, levelpath.c_str(), i);
-
-			if (!Exists(buf))
+			wchar_t levelpath[MAX_PATH];
+			swprintf(levelpath, LengthOfArray(levelpath), L"%s\\%s\\%u.ini",
+				inipath, data.cFileName, i);
+			if (!Exists(levelpath))
 				break;
 
-			const IniFile *inidata = new IniFile(buf);
+			const IniFile *const inidata = new IniFile(levelpath);
 			const IniGroup *entdata;
 			vector<Loop> points;
 			char buf2[8];
@@ -1977,7 +2026,6 @@ static void ProcessLevelPathListINI(const IniGroup *group, const wstring &mod_di
 			paths.push_back(path);
 			delete inidata;
 		}
-		delete[] buf;
 		auto numents = paths.size();
 		PathDataPtr ptr;
 		ptr.LevelAct = levelact;
@@ -1997,14 +2045,17 @@ static void ProcessLevelPathListINI(const IniGroup *group, const wstring &mod_di
 static void ProcessStageLightDataListINI(const IniGroup *group, const wstring &mod_dir)
 {
 	if (!group->hasKeyNonEmpty("filename") || !group->hasKeyNonEmpty("pointer")) return;
-	const IniFile *inidata = new IniFile(mod_dir + L'\\' + group->getWString("filename"));
+	wchar_t filename[MAX_PATH];
+	swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+		mod_dir.c_str(), group->getWString("filename").c_str());
+	const IniFile *const inidata = new IniFile(filename);
 	vector<StageLightData> ents;
 	for (unsigned int i = 0; i < 999; i++)
 	{
 		char key[8];
 		snprintf(key, sizeof(key), "%u", i);
 		if (!inidata->hasGroup(key)) break;
-		const IniGroup *entdata = inidata->getGroup(key);
+		const IniGroup *const entdata = inidata->getGroup(key);
 		StageLightData entry;
 		entry.level = (char)ParseLevelID(entdata->getString("Level"));
 		entry.act = (char)entdata->getInt("Act");
@@ -2484,7 +2535,7 @@ static void __cdecl InitMods()
 		unique_ptr<IniFile> ini_mod(new IniFile(f_mod_ini));
 		fclose(f_mod_ini);
 
-		const IniGroup *modinfo = ini_mod->getGroup("");
+		const IniGroup *const modinfo = ini_mod->getGroup("");
 		const string mod_nameA = modinfo->getString("Name");
 		const wstring mod_name = modinfo->getWString("Name");
 		PrintDebug("%u. %s\n", i, mod_nameA.c_str());
@@ -2649,7 +2700,10 @@ static void __cdecl InitMods()
 		// Check if the mod has EXE data replacements.
 		if (modinfo->hasKeyNonEmpty("EXEData"))
 		{
-			IniFile *exedata = new IniFile(mod_dir + L'\\' + modinfo->getWString("EXEData"));
+			wchar_t filename[MAX_PATH];
+			swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+				mod_dir.c_str(), modinfo->getWString("EXEData").c_str());
+			const IniFile *const exedata = new IniFile(filename);
 			for (auto iter = exedata->cbegin(); iter != exedata->cend(); ++iter)
 			{
 				IniGroup *group = iter->second;
@@ -2665,7 +2719,10 @@ static void __cdecl InitMods()
 		{
 			if (modinfo->hasKeyNonEmpty(dlldatakeys[j]))
 			{
-				IniFile *dlldata = new IniFile(mod_dir + L'\\' + modinfo->getWString(dlldatakeys[j]));
+				wchar_t filename[MAX_PATH];
+				swprintf(filename, LengthOfArray(filename), L"%s\\%s",
+					mod_dir.c_str(), modinfo->getWString(dlldatakeys[j]).c_str());
+				const IniFile *const dlldata = new IniFile(filename);
 				dlllabels.clear();
 				const IniGroup *group = dlldata->getGroup("Files");
 				for (auto iter = group->cbegin(); iter != group->cend(); ++iter)

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -22,6 +22,7 @@ using std::vector;
 #include <dbghelp.h>
 #include <shlwapi.h>
 #include <gdiplus.h>
+#include "resource.h"
 
 #include "git.h"
 #include "version.h"
@@ -41,6 +42,8 @@ using std::vector;
 #include "AutoMipmap.h"
 #include "UiScale.h"
 #include "FixFOV.h"
+
+static HINSTANCE g_hinstDll = nullptr;
 
 /**
  * Replace slash characters with backslashes.
@@ -223,10 +226,6 @@ static windowdata outerSizes[] = {
 // Used for borderless windowed mode.
 // Defines the size of the inner-window on which the game is rendered.
 static windowsize innerSizes[2] = {};
-
-static ACCEL accelerators[] = {
-	{ FALT | FVIRTKEY, VK_RETURN, 0 }
-};
 
 static WNDCLASS outerWindowClass = {};
 static HWND accelWindow          = nullptr;
@@ -498,10 +497,8 @@ static LRESULT CALLBACK WrapperWndProc(HWND wrapper, UINT uMsg, WPARAM wParam, L
 
 		case WM_COMMAND:
 		{
-			if (LOWORD(wParam) != 0)
-			{
+			if (wParam != MAKELONG(ID_FULLSCREEN, 1))
 				break;
-			}
 
 			switchingWindowMode = true;
 
@@ -645,10 +642,8 @@ static LRESULT __stdcall WndProc_Resizable(HWND handle, UINT Msg, WPARAM wParam,
 
 		case WM_COMMAND:
 		{
-			if (LOWORD(wParam) != 0)
-			{
+			if (wParam != MAKELONG(ID_FULLSCREEN, 1))
 				break;
-			}
 
 			if (PresentParameters.Windowed && IsWindowed)
 			{
@@ -825,7 +820,7 @@ static void CreateSADXWindow_r(HINSTANCE hInstance, int nCmdShow)
 		if (accelWindow == nullptr)
 			return;
 
-		accelTable = CreateAcceleratorTable(arrayptrandlength(accelerators));
+		accelTable = LoadAccelerators(g_hinstDll, MAKEINTRESOURCE(IDR_ACCEL_WRAPPER_WINDOW));
 
 		auto& innerSize = innerSizes[windowMode];
 
@@ -860,7 +855,7 @@ static void CreateSADXWindow_r(HINSTANCE hInstance, int nCmdShow)
 		hWnd = CreateWindowExA(dwExStyle, GetWindowClassName(), GetWindowClassName(), dwStyle, x, y,
 			w, h, nullptr, nullptr, hInstance, nullptr);
 
-		accelTable = CreateAcceleratorTable(arrayptrandlength(accelerators));
+		accelTable = LoadAccelerators(g_hinstDll, MAKEINTRESOURCE(IDR_ACCEL_WRAPPER_WINDOW));
 
 		if (!IsWindowed)
 		{
@@ -3109,6 +3104,7 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDll, DWORD fdwReason, LPVOID lpvReserved)
 	switch (fdwReason)
 	{
 	case DLL_PROCESS_ATTACH:
+		g_hinstDll = hinstDll;
 		HookTheAPI();
 
 		// Make sure this is the correct version of SADX.

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -3119,6 +3119,14 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDll, DWORD fdwReason, LPVOID lpvReserved)
 
 		WriteData((unsigned char*)0x401AE1, (unsigned char)0x90);
 		WriteCall((void *)0x401AE2, (void *)LoadChrmodels);
+
+#if !defined(_MSC_VER) || defined(_DLL)
+		// Disable thread library calls, since we don't
+		// care about thread attachments.
+		// NOTE: On MSVC, don't do this if using the static CRT.
+		// Reference: https://msdn.microsoft.com/en-us/library/windows/desktop/ms682579(v=vs.85).aspx
+		DisableThreadLibraryCalls(hinstDll);
+#endif /* !defined(_MSC_VER) || defined(_DLL) */
 		break;
 
 	case DLL_THREAD_ATTACH:

--- a/SADXModLoader/resource.h
+++ b/SADXModLoader/resource.h
@@ -1,0 +1,13 @@
+/**
+ * SADX Mod Loader
+ * Win32 resource script.
+ */
+
+#ifndef SADXMODLOADER_RESOURCE_H
+#define SADXMODLOADER_RESOURCE_H
+
+// Accelerator table for the wrapper window.
+#define IDR_ACCEL_WRAPPER_WINDOW	101
+#define ID_FULLSCREEN			40001
+
+#endif /* SADXMODLOADER_RESOURCE_H */

--- a/SADXModLoader/stdafx.h
+++ b/SADXModLoader/stdafx.h
@@ -10,9 +10,15 @@
 // Windows Header Files:
 #include <windows.h>
 
-#include <algorithm>
+// C
+#include <stdlib.h>
+
+// C (C++ namespace)
 #include <cstdint>
 #include <cstdio>
+
+// C++
+#include <algorithm>
 #include <deque>
 #include <stack>
 #include <fstream>
@@ -22,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <string>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,3 +13,6 @@ platform:
 configuration:
   - Debug
   - Release
+
+before_build:
+  - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,6 @@ configuration:
 
 before_build:
   - git submodule update --init --recursive
+
+build:
+  project: SADXModLoader.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+# AppVeyor configuration file.
+version: '3.7.0.{build}'
+
+# Build worker image (VM template)
+image: Visual Studio 2017
+
+# clone directory
+clone_folder: c:\projects\sadx-mod-loader
+
+platform:
+  - x86
+
+configuration:
+  - Debug
+  - Release

--- a/libmodutils/AnimationFile.h
+++ b/libmodutils/AnimationFile.h
@@ -11,15 +11,15 @@
 class AnimationFile
 {
 public:
-	AnimationFile(const char *filename);
+	explicit AnimationFile(const char *filename);
 #ifdef _MSC_VER
-	AnimationFile(const wchar_t *filename);
+	explicit AnimationFile(const wchar_t *filename);
 #endif /* _MSC_VER */
-	AnimationFile(const std::string &filename);
+	explicit AnimationFile(const std::string &filename);
 #ifdef _MSC_VER
-	AnimationFile(const std::wstring &filename);
+	explicit AnimationFile(const std::wstring &filename);
 #endif /* _MSC_VER */
-	AnimationFile(std::istream &stream);
+	explicit AnimationFile(std::istream &stream);
 
 	NJS_MOTION *getmotion();
 	int getmodelcount();

--- a/libmodutils/GameObject.h
+++ b/libmodutils/GameObject.h
@@ -10,10 +10,10 @@ private:
 protected:
 	ObjectMaster *objData;
 	GameObject(LoadObj flags, int index);
-	GameObject(ObjectMaster *obj);
+	explicit GameObject(ObjectMaster *obj);
 	virtual void Delete();
 public:
-	GameObject(int index);
+	explicit GameObject(int index);
 	~GameObject();
 	virtual void Main() = 0;
 	virtual void Display();
@@ -35,7 +35,7 @@ class GameEntity : GameObject
 protected:
 	EntityData1 *GetData();
 public:
-	GameEntity(int index);
+	explicit GameEntity(int index);
 	char GetAction();
 	void SetAction(char action);
 	short GetInvulnerableTime();

--- a/libmodutils/LandTableInfo.cpp
+++ b/libmodutils/LandTableInfo.cpp
@@ -21,15 +21,6 @@ LandTableInfo::LandTableInfo(const char *filename)
 	str.close();
 }
 
-#ifdef _MSC_VER
-LandTableInfo::LandTableInfo(const wchar_t *filename)
-{
-	ifstream str(filename, ios::binary);
-	init(str);
-	str.close();
-}
-#endif /* _MSC_VER */
-
 LandTableInfo::LandTableInfo(const string &filename)
 {
 	ifstream str(filename, ios::binary);
@@ -38,6 +29,13 @@ LandTableInfo::LandTableInfo(const string &filename)
 }
 
 #ifdef _MSC_VER
+LandTableInfo::LandTableInfo(const wchar_t *filename)
+{
+	ifstream str(filename, ios::binary);
+	init(str);
+	str.close();
+}
+
 LandTableInfo::LandTableInfo(const wstring &filename)
 {
 	ifstream str(filename, ios::binary);

--- a/libmodutils/LandTableInfo.h
+++ b/libmodutils/LandTableInfo.h
@@ -14,11 +14,9 @@ public:
 	struct Metadata { uint32_t size; const uint8_t *data; };
 
 	explicit LandTableInfo(const char *filename);
-#ifdef _MSC_VER
-	explicit LandTableInfo(const wchar_t *filename);
-#endif /* _MSC_VER */
 	explicit LandTableInfo(const std::string &filename);
 #ifdef _MSC_VER
+	explicit LandTableInfo(const wchar_t *filename);
 	explicit LandTableInfo(const std::wstring &filename);
 #endif /* _MSC_VER */
 	explicit LandTableInfo(std::istream &stream);

--- a/libmodutils/LandTableInfo.h
+++ b/libmodutils/LandTableInfo.h
@@ -13,15 +13,15 @@ class LandTableInfo
 public:
 	struct Metadata { uint32_t size; const uint8_t *data; };
 
-	LandTableInfo(const char *filename);
+	explicit LandTableInfo(const char *filename);
 #ifdef _MSC_VER
-	LandTableInfo(const wchar_t *filename);
+	explicit LandTableInfo(const wchar_t *filename);
 #endif /* _MSC_VER */
-	LandTableInfo(const std::string &filename);
+	explicit LandTableInfo(const std::string &filename);
 #ifdef _MSC_VER
-	LandTableInfo(const std::wstring &filename);
+	explicit LandTableInfo(const std::wstring &filename);
 #endif /* _MSC_VER */
-	LandTableInfo(std::istream &stream);
+	explicit LandTableInfo(std::istream &stream);
 
 	LandTable *getlandtable();
 	const std::string &getauthor();

--- a/libmodutils/ModelInfo.cpp
+++ b/libmodutils/ModelInfo.cpp
@@ -21,15 +21,6 @@ ModelInfo::ModelInfo(const char *filename)
 	str.close();
 }
 
-#ifdef _MSC_VER
-ModelInfo::ModelInfo(const wchar_t *filename)
-{
-	ifstream str(filename, ios::binary);
-	init(str);
-	str.close();
-}
-#endif /* _MSC_VER */
-
 ModelInfo::ModelInfo(const string &filename)
 {
 	ifstream str(filename, ios::binary);
@@ -38,6 +29,13 @@ ModelInfo::ModelInfo(const string &filename)
 }
 
 #ifdef _MSC_VER
+ModelInfo::ModelInfo(const wchar_t *filename)
+{
+	ifstream str(filename, ios::binary);
+	init(str);
+	str.close();
+}
+
 ModelInfo::ModelInfo(const wstring &filename)
 {
 	ifstream str(filename, ios::binary);

--- a/libmodutils/ModelInfo.h
+++ b/libmodutils/ModelInfo.h
@@ -21,15 +21,15 @@ class ModelInfo
 public:
 	struct Metadata { uint32_t size; const uint8_t *data; };
 
-	ModelInfo(const char *filename);
+	explicit ModelInfo(const char *filename);
 #ifdef _MSC_VER
-	ModelInfo(const wchar_t *filename);
+	explicit ModelInfo(const wchar_t *filename);
 #endif /* _MSC_VER */
-	ModelInfo(const std::string &filename);
+	explicit ModelInfo(const std::string &filename);
 #ifdef _MSC_VER
-	ModelInfo(const std::wstring &filename);
+	explicit ModelInfo(const std::wstring &filename);
 #endif /* _MSC_VER */
-	ModelInfo(std::istream &stream);
+	explicit ModelInfo(std::istream &stream);
 
 	ModelFormat getformat();
 	NJS_OBJECT *getmodel();

--- a/libmodutils/ModelInfo.h
+++ b/libmodutils/ModelInfo.h
@@ -22,11 +22,9 @@ public:
 	struct Metadata { uint32_t size; const uint8_t *data; };
 
 	explicit ModelInfo(const char *filename);
-#ifdef _MSC_VER
-	explicit ModelInfo(const wchar_t *filename);
-#endif /* _MSC_VER */
 	explicit ModelInfo(const std::string &filename);
 #ifdef _MSC_VER
+	explicit ModelInfo(const wchar_t *filename);
 	explicit ModelInfo(const std::wstring &filename);
 #endif /* _MSC_VER */
 	explicit ModelInfo(std::istream &stream);

--- a/libmodutils/Trampoline.cpp
+++ b/libmodutils/Trampoline.cpp
@@ -1,52 +1,57 @@
 #include "stdafx.h"
 #include "Trampoline.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include <exception>
 #include <vector>
 #include <ninja.h>		// for typedefs
 #include <MemAccess.h>
 
-Trampoline::Trampoline(size_t start, size_t end, void* func, bool destructRevert) :
-	target(nullptr), detour(nullptr), codeData(nullptr), originalSize(0), codeSize(0), revert(destructRevert)
+Trampoline::Trampoline(intptr_t start, intptr_t end, void* func, bool destructRevert)
+	: target(reinterpret_cast<void*>(start))
+	, detour(func)
+	, codeData(nullptr)
+	, originalSize(0)
+	, codeSize(0)
+	, revert(destructRevert)
 {
 	if (start > end)
 		throw std::exception("Start address cannot exceed end address.");
-
 	if (end - start < 5)
 		throw std::exception("Length cannot be less than 5 bytes.");
 
-	target = (void*)start;
-	detour = func;
 	originalSize = end - start;
-	codeSize = originalSize + 5;
+	codeSize = originalSize + 5;	// TODO: Probably not needed...
 
 	// Copy original instructions
 	codeData = VirtualAlloc(nullptr, codeSize, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 	if (codeData == nullptr)
 		throw std::exception("VirtualAlloc failure.");
 
-	// ReadProcessMemory maybe?
+	// memcpy() can be used instead of ReadProcessMemory
+	// because we're not reading memory from another process.
 	memcpy(codeData, target, originalSize);
 
-	auto ptr = (char*)codeData;
+	uint8_t *const ptr = static_cast<uint8_t*>(codeData);
 
 	// If an existing (hopefully) trampoline has been applied to this address,
 	// correct the jump offset for it.
-	if (ptr[0] == 0xE9i8)
+	if (ptr[0] == 0xE9)
 	{
-		int addr = start + 5 + *(int*)&ptr[1];
+		intptr_t addr = start + 5 + *(reinterpret_cast<intptr_t*>(&ptr[1]));
 		WriteJump(ptr, (void*)addr);
 	}
 
 	// Append jump (terribly)
-	WriteJump(&((Uint8*)codeData)[originalSize], (void*)end);
+	WriteJump(&ptr[originalSize], (void*)end);
 
-	// NOP
-	std::vector<Uint8> nop(originalSize, 0x90);
+	// NOP the original code.
+	// NOTE: This is in .text, so we have to use WriteData().
+	// Using memset() will crash.
+	std::vector<uint8_t> nop(originalSize, 0x90);
 	WriteData(target, nop.data(), nop.size());
 
-	// Jump
+	// Write a Jump to the new target function.
 	WriteJump(target, func);
 }
 
@@ -57,6 +62,9 @@ Trampoline::~Trampoline()
 		if (revert)
 			WriteData(target, codeData, originalSize);
 
+		// FIXME: MEM_RELEASE caused problems.
+		// Using MEM_DECOMMIT instead of MEM_RELEASE frees
+		// physical memory, but leaks address space.
 		VirtualFree(codeData, codeSize, MEM_DECOMMIT);
 	}
 }

--- a/libmodutils/Trampoline.h
+++ b/libmodutils/Trampoline.h
@@ -12,7 +12,7 @@ private:
 	void* detour;
 	LPVOID codeData;
 	size_t originalSize;
-	size_t codeSize;
+	size_t codeSize;	// always originalSize + 5
 	const bool revert;
 
 public:
@@ -25,7 +25,7 @@ public:
 	/// <param name="destructRevert">If <c>true</c>, code changes will be reverted when this instance is destroyed.</param>
 	/// <remarks>If there's a relative jump or call within the range of <see cref="start" /> and <see cref="end" />,
 	/// they need to be replaced with absolute offsets before instantiating a <see cref="Trampoline" />.</remarks>
-	Trampoline(size_t start, size_t end, void* func, bool destructRevert = true);
+	Trampoline(intptr_t start, intptr_t end, void* func, bool destructRevert = true);
 	~Trampoline();
 
 	// Pointer to original code.


### PR DESCRIPTION
This PR has a bunch of improvements to various areas. Among other things, the PVR/PVM/GBIX blacklist code now uses more efficient data structures, which improve lookup performance (PVR/PVM now uses a binary search instead of linear; GBIX uses an unordered_set hash lookup instead of linear) and reduces data size (the text arrays are now C string arrays instead of vector<string>).

Other changes include using snprintf()/swprintf() to concatenate strings in many areas instead of C++ strings, which reduces memory allocations.

These changes need testing before merging, since they have the potential to break something. I did some quick tests by starting the program on Wine and Windows 7 and it seems to work, but I don't have any mods installed at the moment.

I also went through the commit log and added notable changes to CHANGES.md.

There's a preliminary appveyor.yml file, but AppVeyor doesn't have D3D8, so I'll need to get that working before it can be enabled on GitHub's webhooks.