### PR TITLE
Fix crashes on Windows XP.

### DIFF
--- a/SADXModLoader/AutoMipmap.cpp
+++ b/SADXModLoader/AutoMipmap.cpp
@@ -818,7 +818,7 @@ namespace mipmap
 	{
 		mip_guard _guard(true);
 
-		FunctionPointer(Sint32, original, (Uint32, IDirect3DTexture8*), sub_77FA10_trampoline.Target());
+		NonStaticFunctionPointer(Sint32, original, (Uint32, IDirect3DTexture8*), sub_77FA10_trampoline.Target());
 		return original(gbix, texture);
 	}
 
@@ -830,7 +830,7 @@ namespace mipmap
 	{
 		mip_guard _guard(true);
 
-		FunctionPointer(void, original, (void*), sub_40D2A0_trampoline.Target());
+		NonStaticFunctionPointer(void, original, (void*), sub_40D2A0_trampoline.Target());
 		original(a1);
 	}
 }

--- a/SADXModLoader/Events.cpp
+++ b/SADXModLoader/Events.cpp
@@ -51,6 +51,6 @@ void OnControl()
 void __cdecl OnExit(UINT uExitCode, int a1, int a2)
 {
 	RaiseEvents(modExitEvents);
-	FunctionPointer(void, original, (UINT, int, int), exitDetour.Target());
+	NonStaticFunctionPointer(void, original, (UINT, int, int), exitDetour.Target());
 	original(uExitCode, a1, a2);
 }

--- a/SADXModLoader/FixFOV.cpp
+++ b/SADXModLoader/FixFOV.cpp
@@ -32,7 +32,7 @@ static void __cdecl njSetScreenDist_r(Angle bams)
 {
 	if (!is_wide)
 	{
-		FunctionPointer(void, original, (Angle), njSetScreenDist_trampoline.Target());
+		NonStaticFunctionPointer(void, original, (Angle), njSetScreenDist_trampoline.Target());
 		original(bams);
 		return;
 	}
@@ -50,7 +50,7 @@ static void __cdecl njSetPerspective_r(Angle bams)
 {
 	if (!is_wide)
 	{
-		FunctionPointer(void, original, (Angle), njSetPerspective_trampoline.Target());
+		NonStaticFunctionPointer(void, original, (Angle), njSetPerspective_trampoline.Target());
 		original(bams);
 		last_bams = HorizontalFOV_BAMS;
 		return;

--- a/SADXModLoader/SADXModLoader.vcxproj
+++ b/SADXModLoader/SADXModLoader.vcxproj
@@ -113,6 +113,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_WINDOWS;_USRDLL;SADXMODLOADER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>.\include;..\extlib\bass;..\libmodutils;..\mod-loader-common\ModLoaderCommon</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -136,6 +137,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NDEBUG;_WINDOWS;_USRDLL;SADXMODLOADER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>.\include;..\extlib\bass;..\libmodutils;..\mod-loader-common\ModLoaderCommon</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/SADXModLoader/TextureReplacement.cpp
+++ b/SADXModLoader/TextureReplacement.cpp
@@ -697,7 +697,9 @@ static void __cdecl LoadPVM_r(const char* filename, NJS_TEXLIST* texlist)
 /// <returns><c>true</c> on success.</returns>
 static bool ReplacePVR(const string& filename, NJS_TEXMEMLIST** tex)
 {
-	static const string index_file = "index.txt";
+	// NOTE: This cannot be `static const string` due to
+	// TLS issues with MSVC 2017 on Windows XP.
+	static const char index_file[] = "index.txt";
 
 	// tl;dr compare the base name of the pvr with the base name of each texpack
 	// entry until a mach is found; otherwise return false.
@@ -713,7 +715,7 @@ static bool ReplacePVR(const string& filename, NJS_TEXMEMLIST** tex)
 		return false;
 	}
 
-	auto offset = index_path.length() - index_file.length();
+	auto offset = index_path.length() - (sizeof(index_file)-1);
 	auto end = index_path.substr(offset);
 	auto path = index_path.substr(0, --offset);
 

--- a/SADXModLoader/UiScale.cpp
+++ b/SADXModLoader/UiScale.cpp
@@ -366,7 +366,7 @@ static void __cdecl njDrawSprite2D_Queue_r(NJS_SPRITE *sp, Int n, Float pri, NJD
 		return;
 	}
 
-	FunctionPointer(void, original, (NJS_SPRITE*, Int, Float, NJD_SPRITE, QueuedModelFlagsB), njDrawSprite2D_Queue_t.Target());
+	NonStaticFunctionPointer(void, original, (NJS_SPRITE*, Int, Float, NJD_SPRITE, QueuedModelFlagsB), njDrawSprite2D_Queue_t.Target());
 
 	// Scales lens flare and sun.
 	// It uses njProjectScreen so there's no position scaling required.

--- a/SADXModLoader/include/MemAccess.h
+++ b/SADXModLoader/include/MemAccess.h
@@ -192,6 +192,12 @@ static inline BOOL WriteCall(void *writeaddress, void *funcaddress)
 	static RETURN_TYPE (__thiscall *const NAME)ARGS = (RETURN_TYPE (__thiscall *)ARGS)ADDRESS
 #define VoidFunc(NAME, ADDRESS) FunctionPointer(void,NAME,(void),ADDRESS)
 
+// Non-static FunctionPointer.
+// If declaring a FunctionPointer within a function, use this one instead.
+// Otherwise, the program will crash on Windows XP.
+#define NonStaticFunctionPointer(RETURN_TYPE, NAME, ARGS, ADDRESS) \
+	RETURN_TYPE (__cdecl *const NAME)ARGS = (RETURN_TYPE (__cdecl *)ARGS)ADDRESS
+
 #define patchdecl(address,data) { (void*)address, arrayptrandsize(data) }
 #define ptrdecl(address,data) { (void*)address, (void*)data }
 

--- a/libmodutils/libmodutils.vcxproj
+++ b/libmodutils/libmodutils.vcxproj
@@ -56,6 +56,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\SADXModLoader\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -72,6 +73,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\SADXModLoader\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
MSVC 2017 (and 2015) have problems using thread-local storage on Windows XP. This showed up when using FunctionPointer() inside of a function where the argument is the result from Trampoline::Target(), since it needs TLS access here. It also caused a problem with a `static const string` within a function.

Solutions:
1. New macro NonStaticFunctionPointer() that works like FunctionPointer() but isn't static.
2. Changed the `static const string` to `static const char[]`.

This fixes SADX on my Windows XP VM.

This bug was reported by @PiKeyAr in #x-hax.

EDIT: A similar bug was reported for wxWidgets: https://trac.wxwidgets.org/ticket/17403

EDIT 2: This was introduced in MSVC 2015: https://docs.microsoft.com/en-us/cpp/build/reference/zc-threadsafeinit-thread-safe-local-static-initialization - it can be disabled using `/Zc:threadSafeInit-`.

EDIT 3: From that page: (emphasis added)

>The implementation of this feature relies on Windows operating system support functions in Windows Vista and later operating systems. **Windows XP, Windows Server 2003, and older operating systems do not have this support, so they do not get the efficiency advantage.** These operating systems also have a lower limit on the number of TLS sections that can be loaded. **Exceeding the TLS section limit can cause a crash.** If this is a problem in your code, especially in code that must run on older operating systems, use /Zc:threadSafeInit- to disable the thread-safe initialization code.