### PR TITLE
MainForm: Fix top/bottom arrow buttons on Windows 7.

### DIFF
--- a/SADXModManager/MainForm.cs
+++ b/SADXModManager/MainForm.cs
@@ -23,6 +23,7 @@ namespace SADXModManager
 	{
 		public MainForm()
 		{
+			this.Font = SystemFonts.MessageBoxFont;
 			InitializeComponent();
 
 			// WORKAROUND: Windows 7's system fonts don't have

--- a/SADXModManager/MainForm.cs
+++ b/SADXModManager/MainForm.cs
@@ -24,6 +24,31 @@ namespace SADXModManager
 		public MainForm()
 		{
 			InitializeComponent();
+
+			// WORKAROUND: Windows 7's system fonts don't have
+			// U+2912 or U+2913. Use Cambria instead.
+			// TODO: Check the actual font to see if it has the glyphs.
+			Font boldFont = null;
+			OperatingSystem os = Environment.OSVersion;
+			if ((os.Platform == PlatformID.Win32NT || os.Platform == PlatformID.Win32Windows) &&
+				(os.Version.Major < 6 || (os.Version.Major == 6 && os.Version.Minor < 2)))
+			{
+				// Windows 7 or earlier.
+				// TODO: Make sure this font exists.
+				// NOTE: U+2912 and U+2913 are missing in Bold, so use Regular.
+				boldFont = new Font("Cambria", this.Font.Size * 1.25f, FontStyle.Regular);
+			}
+			else
+			{
+				// Newer than Windows 7, or not Windows.
+				// Use the default font.
+				boldFont = new Font(this.Font.FontFamily, this.Font.Size * 1.25f, FontStyle.Bold);
+			}
+
+			modTopButton.Font = boldFont;
+			modUpButton.Font = boldFont;
+			modDownButton.Font = boldFont;
+			modBottomButton.Font = boldFont;
 		}
 
 		private bool checkedForUpdates;

--- a/SADXModManager/MainForm.designer.cs
+++ b/SADXModManager/MainForm.designer.cs
@@ -468,7 +468,6 @@
 			this.modBottomButton.AutoSize = true;
 			this.modBottomButton.Enabled = false;
 			this.modBottomButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.modBottomButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.modBottomButton.Location = new System.Drawing.Point(344, 90);
 			this.modBottomButton.Name = "modBottomButton";
 			this.modBottomButton.Size = new System.Drawing.Size(28, 22);
@@ -483,7 +482,6 @@
 			this.modTopButton.AutoSize = true;
 			this.modTopButton.Enabled = false;
 			this.modTopButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.modTopButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.modTopButton.Location = new System.Drawing.Point(344, 6);
 			this.modTopButton.Name = "modTopButton";
 			this.modTopButton.Size = new System.Drawing.Size(28, 22);
@@ -510,7 +508,6 @@
 			this.modDownButton.AutoSize = true;
 			this.modDownButton.Enabled = false;
 			this.modDownButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.modDownButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.modDownButton.Location = new System.Drawing.Point(344, 62);
 			this.modDownButton.Name = "modDownButton";
 			this.modDownButton.Size = new System.Drawing.Size(28, 22);
@@ -525,7 +522,6 @@
 			this.modUpButton.AutoSize = true;
 			this.modUpButton.Enabled = false;
 			this.modUpButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.modUpButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.modUpButton.Location = new System.Drawing.Point(344, 34);
 			this.modUpButton.Name = "modUpButton";
 			this.modUpButton.Size = new System.Drawing.Size(28, 22);


### PR DESCRIPTION
Windows 7's default fonts don't have U+2912 ('⤒') or U+2913 ('⤓'). This PR switches those two buttons to use Cambria on Windows 7 and earlier.

NOTE: Cambria was introduced on Windows Vista, so the buttons are still broken on Windows XP.

In addition, MainForm's font is now set to the Message Box font, which matches the OS default dialog font. This is a better font than Microsoft Sans Serif. I didn't apply this to any other forms yet due to layout issues.

This fixes issue #38. (Incompatible symbols in the Mod Manager (Windows 7))