### PR TITLE
Minor optimizations

### DIFF
--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1528,7 +1528,7 @@ static void __cdecl InitMods()
 				DWORD error = GetLastError();
 				LPWSTR buffer;
 				size_t size = FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-					nullptr, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&buffer, 0, nullptr);
+					nullptr, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL), (LPWSTR)&buffer, 0, nullptr);
 				bool allocated = (size != 0);
 
 				if (!allocated)

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -1535,7 +1535,7 @@ static void __cdecl InitMods()
 				{
 					static const wchar_t fmterr[] = L"Unable to format error message.";
 					buffer = const_cast<LPWSTR>(fmterr);
-					size = LengthOfArray(fmterr);
+					size = LengthOfArray(fmterr)-1;
 				}
 				wstring message(buffer, size);
 				if (allocated)

--- a/SADXModLoader/include/MemAccess.h
+++ b/SADXModLoader/include/MemAccess.h
@@ -131,9 +131,9 @@ static inline BOOL WriteData(void *writeaddress, const T(&data)[N])
  * @return Nonzero on success; 0 on error (check GetLastError()).
  */
 template <int count>
-static inline BOOL WriteData(void *address, const char data, SIZE_T *byteswritten)
+static inline BOOL WriteData(void *address, uint8_t data, SIZE_T *byteswritten)
 {
-	char buf[count];
+	uint8_t buf[count];
 	memset(buf, data, count);
 	int result = WriteData(address, buf, count, byteswritten);
 	return result;
@@ -146,7 +146,7 @@ static inline BOOL WriteData(void *address, const char data, SIZE_T *byteswritte
  * @return Nonzero on success; 0 on error (check GetLastError()).
  */
 template <int count>
-static inline BOOL WriteData(void *address, char data)
+static inline BOOL WriteData(void *address, uint8_t data)
 {
 	return WriteData<count>(address, data, nullptr);
 }

--- a/SADXModLoader/include/SADXFunctions.h
+++ b/SADXModLoader/include/SADXFunctions.h
@@ -736,7 +736,7 @@ FunctionPointer(bool, IsTwinkleCircuit, (), 0x4B5040);
 FunctionPointer(void, HudShowScore, (int), 0x4B50E0);
 FunctionPointer(int, GetCurrentCharIDOrSomething, (), 0x4B5A30);
 FunctionPointer(ObjectMaster *, LoadCharBoss, (ObjectMaster *a1), 0x4B6050);
-FunctionPointer(void, DisplayHintText, (const char **strings, int duration), 0x4B79C0);
+FunctionPointer(void, DisplayHintText, (const char *const *strings, int duration), 0x4B79C0);
 FunctionPointer(signed int, GetHintText, (int id, int *data), 0x4B7C10);
 FunctionPointer(signed int, ProcessAnimatedModelNode_Instanced, (NJS_MATRIX_PTR a1, NJS_ACTION *a2, float n, Uint32 instance, NJS_MATRIX_PTR a5), 0x4B81F0);
 FunctionPointer(Sint32, SetInstancedMatrix, (Uint32 index, NJS_MATRIX_PTR matrix), 0x4B82D0);


### PR DESCRIPTION
Here's some minor optimizations.

* Use `uint8_t` for single-byte WriteData functions. This eliminates some warnings when writing bytes >= 0x80.
* Changed DisplayHintText's `strings` parameter to `const char *const *`.
* dllmain.cpp: Use Unicode strings where possible. Also, clear the errors vector when we're done using it.