### PR TITLE
Ignore WM_SYSKEYDOWN and WM_SYSKEYUP in WndProc

### DIFF
--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -540,10 +540,10 @@ static LRESULT CALLBACK WndProc_Resizable(HWND handle, UINT Msg, WPARAM wParam, 
 			break;
 			
 		case WM_SYSKEYDOWN:
-			return 0;
+			if (wParam != VK_F4 && wParam != VK_F2 && wParam != VK_RETURN) return 0;
 
 		case WM_SYSKEYUP:
-			return 0;
+			if (wParam != VK_F4 && wParam != VK_F2 && wParam != VK_RETURN) return 0;
 
 		case WM_DESTROY:
 			PostQuitMessage(0);
@@ -608,7 +608,7 @@ LRESULT __stdcall WndProc_hook(HWND handle, UINT Msg, WPARAM wParam, LPARAM lPar
 {
 	if (Msg == WM_SYSKEYUP || Msg == WM_SYSKEYDOWN)
 	{
-		return 0;
+		if (wParam != VK_F4 && wParam != VK_F2 && wParam != VK_RETURN) return 0;
 	}
 	else return DefWindowProcA(handle, Msg, wParam, lParam);
 }

--- a/SADXModLoader/dllmain.cpp
+++ b/SADXModLoader/dllmain.cpp
@@ -538,6 +538,12 @@ static LRESULT CALLBACK WndProc_Resizable(HWND handle, UINT Msg, WPARAM wParam, 
 	{
 		default:
 			break;
+			
+		case WM_SYSKEYDOWN:
+			return 0;
+
+		case WM_SYSKEYUP:
+			return 0;
 
 		case WM_DESTROY:
 			PostQuitMessage(0);
@@ -600,7 +606,11 @@ static LRESULT CALLBACK WndProc_Resizable(HWND handle, UINT Msg, WPARAM wParam, 
 
 LRESULT __stdcall WndProc_hook(HWND handle, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
-	return DefWindowProcA(handle, Msg, wParam, lParam);
+	if (Msg == WM_SYSKEYUP || Msg == WM_SYSKEYDOWN)
+	{
+		return 0;
+	}
+	else return DefWindowProcA(handle, Msg, wParam, lParam);
 }
 
 wstring borderimg = L"mods\\Border.png";


### PR DESCRIPTION
This prevents SADX from hanging when pressing Alt or F10. Alt+F2, Alt+F4 and Alt+Enter etc. functionality is still intact.