### PR TITLE
Update "Disable Music" code

### DIFF
--- a/data/Codes.lst
+++ b/data/Codes.lst
@@ -45,7 +45,7 @@ Code "Have All Upgrades"
 or16 p03B42E30|20|C0|4 0x7FFF
 
 Patch "Disable Music"
-write8 00425690 0xC3
+write8 0091268C 0
 
 Patch "Disable Voices"
 write8 00425710 0xC3


### PR DESCRIPTION
Replaced the "Disable Music" code to set the `Music_Enabled` value to 0. This also disables music in Adventure Fields. Fixes #54 